### PR TITLE
add reaction mode

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,6 +1,8 @@
 class ApplicationController < ActionController::Base
   include SessionsHelper
 
+
+
   # ログイン済みユーザーかどうか確認
   def logged_in_user
     unless logged_in?
@@ -15,4 +17,15 @@ class ApplicationController < ActionController::Base
     @user = User.find(params[:id])
     redirect_to(root_url) unless current_user?(@user)
   end
+
+  # 管理ユーザーかどうか確認
+  def admined_user
+    if !logged_in?
+      store_location
+      redirect_to login_url
+    elsif !current_user.admin?
+      redirect_to root_url
+    end
+  end
+
 end

--- a/app/controllers/questions_controller.rb
+++ b/app/controllers/questions_controller.rb
@@ -31,13 +31,5 @@ class QuestionsController < ApplicationController
 
   #before action
 
-  # 管理ユーザーかどうか確認
-  def admined_user
-    if !logged_in?
-      store_location
-      redirect_to login_url
-    elsif !current_user.admin?
-      redirect_to root_url
-    end
-  end
+  
 end

--- a/app/controllers/reactions_controller.rb
+++ b/app/controllers/reactions_controller.rb
@@ -1,0 +1,47 @@
+class ReactionsController < ApplicationController
+
+  def index
+    @reactions = current_user.reactions.where(["created_at Like ?", "%#{params[:created_at]}%"])
+    @statesment = @reactions.map{|reaction| Reaction.find_by(id: reaction.statement_id)}.uniq
+    @reactions = Kaminari.paginate_array(@reactions).page(params[:page]).per(5)
+  end
+
+  def new
+    @statement = Statement.where( 'id >= ?', rand(Statement.first.id..Statement.last.id) ).first
+    @reaction = @statement.reactions.new
+  end
+
+  def create
+    @statement = Statement.find(params[:id])
+    @reaction = @statement.reactions.new(reaction_params)
+    @reaction.assign_attributes(user_id: current_user.id)
+    if @reaction.save
+      redirect_to new_reaction_path
+    else
+      redirect_to new_reaction_path
+    end
+  end
+
+  def edit
+    @reaction = current_user.reactions.find(params[:id])
+    @statement = Statement.find_by(id: @reaction.statement_id)
+  end
+
+  def update
+    @reaction = current_user.reactions.find(params[:id])
+    @statement = Statement.find_by(id: @reaction.statement_id)
+    if @reaction.update(reaction_params)
+      flash.now[:success] = "回答を保存しました。"
+      render 'edit'
+    else
+      flash.now[:danger] = "回答を保存できませんでした。"
+      render 'edit'
+    end
+  end
+
+  private
+
+  def reaction_params
+    params.require(:reaction).permit(:content)
+  end
+end

--- a/app/controllers/statements_controller.rb
+++ b/app/controllers/statements_controller.rb
@@ -1,0 +1,32 @@
+class StatementsController < ApplicationController
+  before_action :admined_user
+  
+  def index
+    @statements = Statement.all
+  end
+
+  def new
+    @form = Form::StatementCollection.new
+  end
+
+  def create
+    @form = Form::StatementCollection.new(statement_collection_params)
+    if @form.save
+      redirect_to root_url
+    else
+      render 'new'
+    end
+  end
+
+  def destroy
+    Statement.find(params[:id]).destroy
+    redirect_to statements_path
+  end
+
+
+  private
+
+  def statement_collection_params
+    params.require(:form_statement_collection).permit(statements_attributes: :content)
+  end
+end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -4,7 +4,9 @@ class UsersController < ApplicationController
 
   def show
     @user = current_user
-    @dates = current_user.answers.map{|dates| dates.created_at.to_date}.uniq
+    @answers_dates = current_user.answers.map{|dates| dates.created_at.to_date}
+    @reactions_dates = current_user.reactions.map{|dates| dates.created_at.to_date}
+    @dates = @answers_dates.push(@reactions_dates).flatten.uniq.sort.reverse
     @dates = Kaminari.paginate_array(@dates).page(params[:page]).per(5)
 
   end

--- a/app/helpers/reactions_helper.rb
+++ b/app/helpers/reactions_helper.rb
@@ -1,0 +1,2 @@
+module ReactionsHelper
+end

--- a/app/helpers/statements_helper.rb
+++ b/app/helpers/statements_helper.rb
@@ -1,0 +1,2 @@
+module StatementsHelper
+end

--- a/app/models/form/statement_collection.rb
+++ b/app/models/form/statement_collection.rb
@@ -1,0 +1,27 @@
+class Form::StatementCollection < Form::Base
+  FORM_COUNT = 10
+  attr_accessor :statements
+
+  def initialize(attributes = {})
+    super attributes
+    self.statements = FORM_COUNT.times.map { Statement.new() } unless self.statements.present?
+  end
+
+  # 上でsuper attributesとしているので必要
+  def statements_attributes=(attributes)
+    self.statementss = attributes.map { |_, v| Statement.new(v) }
+  end
+
+  def save
+    # 実際にやりたいことはこれだけ
+    # self.memos.map(&:save!)
+
+    # 複数件全て保存できた場合のみ実行したいので、transactionを使用する
+    Statement.transaction do
+      self.statements.map(&:save!)
+    end
+      return true
+    rescue => e
+      return false
+  end
+end

--- a/app/models/reaction.rb
+++ b/app/models/reaction.rb
@@ -1,0 +1,6 @@
+class Reaction < ApplicationRecord
+  belongs_to :user
+  belongs_to :statement
+  default_scope -> { order(created_at: :desc) }
+  validates :content, presence: true, length: {maximum: 255}
+end

--- a/app/models/statement.rb
+++ b/app/models/statement.rb
@@ -1,0 +1,4 @@
+class Statement < ApplicationRecord
+  has_many :reactions, dependent: :destroy
+  validates :content, presence: true, length: {maximum: 255}
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -10,6 +10,7 @@ class User < ApplicationRecord
   has_secure_password
   validates :password, presence: true, length: { minimum: 6 }, allow_nil:true
   has_many :answers, dependent: :destroy
+  has_many :reactions, dependent: :destroy
 
   # 渡された文字列のハッシュ値を返す
   def User.digest(string)

--- a/app/views/questions/index.html.erb
+++ b/app/views/questions/index.html.erb
@@ -1,5 +1,7 @@
 <%= provide(:title, "問題一覧") %>
 
+<h1>Explainモード問題一覧</h1>
+<%= link_to "Statements一覧", statements_path %>
 <section class = "list">
   <% @questions.each do |question| %>
     <li><%= question.content %></li>

--- a/app/views/questions/new.html.erb
+++ b/app/views/questions/new.html.erb
@@ -1,5 +1,8 @@
 <%= provide(:title, "Create Questions") %>
 
+
+  <h1>Explainモード質問作成</h1>
+  <%= link_to "Reactionモード質問作成ページへ", new_statement_path %>
   <%= form_with(model: @form, url: questions_path, local: true) do |f| %>
 
     <%= f.fields_for :questions do |i| %>

--- a/app/views/reactions/edit.html.erb
+++ b/app/views/reactions/edit.html.erb
@@ -1,0 +1,20 @@
+<% provide(:title, "添削") %>
+<div class="text-center items-center justify-center ">
+
+
+  <h1 class="text-2xl w-full max-w-md h-full container mx-auto bg-white shadow-md rounded-lg px-8 pt-6 pb-8 mb-4">
+  <%= @statement.content %></h1>
+
+
+    <%= form_with(model: @reaction, local: true) do |f| %>
+
+      <%= f.text_area :content, class:"content-center resize-none text-2xl h-36 pl-3 pt-3 h-10 w-full border border-solid rounded-lg border-black" %>
+
+      <%= f.submit "添削内容を保存する", class:"mx-auto w-42 mt-4 mb-4 bg-white hover:bg-blue-500 text-blue-700 font-semibold hover:text-white py-2 px-4 border border-blue-500 hover:border-transparent rounded block" %>
+      <%= link_to "回答一覧に戻る", reactions_path(created_at: @reaction.created_at.to_date) ,class:"font-bold underline text-blue-500 hover:text-blue-300 "%>
+
+    <% end %>
+
+
+</div>
+

--- a/app/views/reactions/index.html.erb
+++ b/app/views/reactions/index.html.erb
@@ -1,17 +1,17 @@
-<% provide(:title, "回答一覧") %>
+<% provide(:title, "reactions一覧") %>
 
 <div class="text-center items-center justify-center">
-  <%= link_to "Reactionモードの回答を見る", reactions_path(created_at: params[:created_at])%>
-  <% @answers.each do |answer| %>
+
+  <%= link_to "Explainモードの回答を見る", answers_path(created_at: params[:created_at])%>
+
+  <% @reactions.each do |reaction| %>
     <li class="mt-4 break-words h-32 bg-white list-none text-2xl border border-solid border-black rounded-lg">
-    <%= answer.content %> </li>
+    <%= reaction.content %> </li>
     <button class="w-36 mt-4 bg-white hover:bg-blue-500 text-blue-700 font-semibold hover:text-white py-2 px-4 border border-blue-500 hover:border-transparent rounded">
-    <%= link_to "添削する", edit_answer_path(answer), class: "block" %></button>
+    <%= link_to "添削する", edit_reaction_path(reaction), class: "block" %></button>
 
   <% end %>
   <div class="text-center">
-    <%= paginate @answers %>
+    <%= paginate @reactions %>
   </div>
 </div>
-
-

--- a/app/views/reactions/new.html.erb
+++ b/app/views/reactions/new.html.erb
@@ -1,0 +1,19 @@
+<%= provide(:title, "React Statements") %>
+
+ <div class="text-2xl w-full max-w-md h-full container mx-auto bg-white shadow-md rounded-lg px-8 pt-6 pb-8 mb-4">
+   <%= @statement.content %>
+ </div>
+
+  <%= form_with(model: @reaction, local: true) do |f| %>
+  <%= hidden_field_tag :id, @statement.id %>
+
+    <%= f.text_area :content, class: "content-center resize-none text-2xl h-36 pl-3 pt-3 h-10 w-full border-solid border-2 rounded border-gray-600" %>
+    <div class="text-center">
+      <%= f.submit "次の問題へ進む", class: "w-36 mt-4 bg-white hover:bg-blue-500 text-blue-700 font-semibold hover:text-white py-2 px-4 border border-blue-500 hover:border-transparent rounded" %>
+    </div>
+
+  <% end %>
+  <div class="text-center mt-10">
+     <%= link_to "終了する", root_path , class: "bg-gray-300 hover:bg-gray-200 text-black font-semibold hover:text-white py-2 px-4 border border-gray-500 hover:border-transparent rounded" %>
+  </div>
+

--- a/app/views/statements/index.html.erb
+++ b/app/views/statements/index.html.erb
@@ -1,0 +1,11 @@
+<%= provide(:title, "問題一覧") %>
+
+<h1>Statements一覧</h1>
+<%= link_to "Questions一覧", questions_path %>
+<section class = "list">
+  <% @statements.each do |statement| %>
+    <li><%= statement.content %></li>
+    <li><%= link_to "削除",  statement, method: :delete,
+                                  data: { confirm: "You sure?" } %></li>
+  <% end %>
+</section>

--- a/app/views/statements/new.html.erb
+++ b/app/views/statements/new.html.erb
@@ -1,0 +1,14 @@
+<%= provide(:title, "Create Statements") %>
+
+  <h1>Reactionモード質問作成</h1>
+  <%= link_to "Explainモード質問作成ページへ", new_answer_path %>
+  <%= form_with(model: @form, url: statements_path, local: true) do |f| %>
+
+    <%= f.fields_for :statements do |i| %>
+      <%= i.text_field :content %>
+    <% end %>
+
+
+    <%= f.submit "作成", class: "btn" %>
+
+  <% end %>

--- a/app/views/static_pages/home.html.erb
+++ b/app/views/static_pages/home.html.erb
@@ -10,6 +10,17 @@
   </button>
 </section>
 
+<section class ="bg-blue-900 container mx-auto w-3/4 my-20 py-3.5 text-center text-white text-3xl
+                 rounded-lg border-solid border-4 border-white">
+  <h1 class = "font-bold">Reaction モード</h1>
+  <p class="p-10 text-lg">ランダムに表示される発言に英文でリアクション</p>
+  <p class="text-lg">5W1Hを意識してなるべく長文で回答してみましょう</p>
+  <P class= "text-lg">制限時間: 45秒</p>
+  <button class= "my-10 bg-white hover:bg-blue-500 text-blue-700 font-semibold hover:text-white py-2 px-4 border border-blue-500 hover:border-transparent rounded" >
+    <%= link_to "学習開始!", new_reaction_path %>
+  </button>
+</section>
+
 
 
 

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -3,16 +3,22 @@
 
 <div class="text-center flex items-center justify-center">
   <div class="mt-4">
+
     <% @dates.each do |record| %>
       <li class="w-56 bg-white list-none underline text-black mt-5 font-bold text-2xl
-                 border border-solid border-white rounded-full hover:bg-black hover:text-white">
-       <%= link_to record, answers_path(created_at: record), class:"block" %>
+                  border border-solid border-white rounded-full hover:bg-black hover:text-white">
+
+       <%= link_to record, answers_path(created_at: record), class: "block" %>
+
       </li>
     <% end %>
+
+
   </div>
   <div class="w-1/2 absolute mt-96 text-center">
     <%= paginate @dates %>
   </div>
+
 </div>
 
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,9 @@
 Rails.application.routes.draw do
+  get 'statements/index'
+  get 'statements/new'
+  get 'reactions/index'
+  get 'reactions/new'
+  get 'reactions/edit'
   get 'answers/new'
   get 'answers/edit'
   get 'questions/new'
@@ -20,5 +25,7 @@ Rails.application.routes.draw do
   resources :password_resets, only: [:new, :create, :edit, :update]
   resources :questions
   resources :answers
+  resources :statements
+  resources :reactions
 
 end

--- a/db/migrate/20210908103554_create_statements.rb
+++ b/db/migrate/20210908103554_create_statements.rb
@@ -1,0 +1,9 @@
+class CreateStatements < ActiveRecord::Migration[6.0]
+  def change
+    create_table :statements do |t|
+      t.text :content
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20210908104508_create_reactions.rb
+++ b/db/migrate/20210908104508_create_reactions.rb
@@ -1,0 +1,12 @@
+class CreateReactions < ActiveRecord::Migration[6.0]
+  def change
+    create_table :reactions do |t|
+      t.text :content
+      t.references :user, null: false, foreign_key: true
+      t.references :statement, null: false, foreign_key: true
+
+      t.timestamps
+    end
+    add_index :reactions, [:user_id, :statement_id, :created_at]
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_08_29_095145) do
+ActiveRecord::Schema.define(version: 2021_09_08_104508) do
 
   create_table "answers", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3", force: :cascade do |t|
     t.text "content"
@@ -24,6 +24,23 @@ ActiveRecord::Schema.define(version: 2021_08_29_095145) do
   end
 
   create_table "questions", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3", force: :cascade do |t|
+    t.text "content"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+  end
+
+  create_table "reactions", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3", force: :cascade do |t|
+    t.text "content"
+    t.bigint "user_id", null: false
+    t.bigint "statement_id", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["statement_id"], name: "index_reactions_on_statement_id"
+    t.index ["user_id", "statement_id", "created_at"], name: "index_reactions_on_user_id_and_statement_id_and_created_at"
+    t.index ["user_id"], name: "index_reactions_on_user_id"
+  end
+
+  create_table "statements", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3", force: :cascade do |t|
     t.text "content"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
@@ -47,4 +64,6 @@ ActiveRecord::Schema.define(version: 2021_08_29_095145) do
 
   add_foreign_key "answers", "questions"
   add_foreign_key "answers", "users"
+  add_foreign_key "reactions", "statements"
+  add_foreign_key "reactions", "users"
 end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,3 +1,4 @@
+
 # メインのサンプルユーザーを1人作成する
 User.create!(name:  "Example User",
   email: "example@railstutorial.org",
@@ -7,4 +8,17 @@ User.create!(name:  "Example User",
   activated_at: Time.zone.now,
   admin: true)
 
+Question.create!(content: "test question")
+
+Statement.create!(content: "test statement")
+
+Answer.create!(content: "test",
+  user_id: 1,
+  question_id: 1,
+  created_at: Time.current.yesterday)
+
+Reaction.create!(content: "reaction 1",
+  user_id: 1,
+  statement_id: 1,
+  created_at: Time.current.yesterday)
 

--- a/spec/factories/reactions.rb
+++ b/spec/factories/reactions.rb
@@ -1,0 +1,7 @@
+FactoryBot.define do
+  factory :reaction do
+    content { "MyText" }
+    user { nil }
+    statement { nil }
+  end
+end

--- a/spec/factories/statements.rb
+++ b/spec/factories/statements.rb
@@ -1,0 +1,5 @@
+FactoryBot.define do
+  factory :statement do
+    content { "MyText" }
+  end
+end

--- a/spec/helpers/reactions_helper_spec.rb
+++ b/spec/helpers/reactions_helper_spec.rb
@@ -1,0 +1,15 @@
+require 'rails_helper'
+
+# Specs in this file have access to a helper object that includes
+# the ReactionsHelper. For example:
+#
+# describe ReactionsHelper do
+#   describe "string concat" do
+#     it "concats two strings with spaces" do
+#       expect(helper.concat_strings("this","that")).to eq("this that")
+#     end
+#   end
+# end
+RSpec.describe ReactionsHelper, type: :helper do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/helpers/statements_helper_spec.rb
+++ b/spec/helpers/statements_helper_spec.rb
@@ -1,0 +1,15 @@
+require 'rails_helper'
+
+# Specs in this file have access to a helper object that includes
+# the StatementsHelper. For example:
+#
+# describe StatementsHelper do
+#   describe "string concat" do
+#     it "concats two strings with spaces" do
+#       expect(helper.concat_strings("this","that")).to eq("this that")
+#     end
+#   end
+# end
+RSpec.describe StatementsHelper, type: :helper do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/models/reaction_spec.rb
+++ b/spec/models/reaction_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe Reaction, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/models/statement_spec.rb
+++ b/spec/models/statement_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe Statement, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/requests/reactions_request_spec.rb
+++ b/spec/requests/reactions_request_spec.rb
@@ -1,0 +1,26 @@
+# require 'rails_helper'
+
+# RSpec.describe "Reactions", type: :request do
+
+#   describe "GET /index" do
+#     it "returns http success" do
+#       get "/reactions/index"
+#       expect(response).to have_http_status(:success)
+#     end
+#   end
+
+#   describe "GET /new" do
+#     it "returns http success" do
+#       get "/reactions/new"
+#       expect(response).to have_http_status(:success)
+#     end
+#   end
+
+#   describe "GET /edit" do
+#     it "returns http success" do
+#       get "/reactions/edit"
+#       expect(response).to have_http_status(:success)
+#     end
+#   end
+
+# end

--- a/spec/requests/statements_request_spec.rb
+++ b/spec/requests/statements_request_spec.rb
@@ -1,0 +1,19 @@
+# require 'rails_helper'
+
+# RSpec.describe "Statements", type: :request do
+
+#   describe "GET /index" do
+#     it "returns http success" do
+#       get "/statements/index"
+#       expect(response).to have_http_status(:success)
+#     end
+#   end
+
+#   describe "GET /new" do
+#     it "returns http success" do
+#       get "/statements/new"
+#       expect(response).to have_http_status(:success)
+#     end
+#   end
+
+# end


### PR DESCRIPTION
reaction mode実装。
reaction model, statement model, reaction_controller, statement_controller追加。
それぞれanswer model, question model, answer_controller, question_controllerと概ね同じ構成。
userページの学習記録において同じ日付リンクから両方の回答を確認できるように実装。

