### PR TITLE
feat: introduce flash messages chore: vuex vue-flash-message

### DIFF
--- a/app/controllers/api/users_controller.rb
+++ b/app/controllers/api/users_controller.rb
@@ -12,9 +12,6 @@ class Api::UsersController < ApplicationController
     @user = User.new(user_params)
     if @user.save
       @user.send_activation_email
-      # flash[:success] = "認証用メールを送信しました。ご確認ください。"
-      # redirect_to root_url
-
     else
       render json: @user.errors, status: :unprpcessable_entity
     end

--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -11,11 +11,13 @@ require("channels")
 
 import { createApp } from "vue";
 import App from "../src/App.vue";
-import { router } from '../src/router'
+import { router } from '../src/router';
+import FlashMessage from '@smartweb/vue-flash-message';
 
 document.addEventListener("DOMContentLoaded", () => {
   const app = createApp(App);
-  app.use(router)
+  app.use(router);
+  app.use(FlashMessage);
   app.mount("#application");
 });
 

--- a/app/javascript/src/App.vue
+++ b/app/javascript/src/App.vue
@@ -2,6 +2,7 @@
   <main>
     <Header nav1="ログイン" nav2="新規登録"/>
     <div class="flex-grow p-24 ">
+      <FlashMessage position="left top"></FlashMessage>
       <router-view />
     </div>
     <Footer link1="home" link2="about" link3="contact" link4="利用規約"/>
@@ -12,11 +13,13 @@
 import Header from './components/Header'
 import Footer from './components/Footer'
 
+
 export default {
   name: 'App',
   components: {
     Header,
     Footer,
+
 
   }
 }

--- a/app/javascript/src/pages/Home.vue
+++ b/app/javascript/src/pages/Home.vue
@@ -14,6 +14,7 @@
         <span>ゲストログイン</span>
       </button>
    </div>
+   
 
   </div>
 </template>

--- a/app/javascript/src/store.js
+++ b/app/javascript/src/store.js
@@ -1,0 +1,20 @@
+
+// import  { createStore } from 'vuex'
+
+// export const store = createStore ({
+//   state() {
+//     return {
+//       message: 'This is store data',
+//       counter: 0,
+//     }
+//   },
+//   mutations: {
+//     count: (state, obj) => {
+//       state.message = obj.message
+//       state.counter += obj.add
+//     },
+//     reset: (state)=> {
+//       state.counter = 0
+//     }
+//   },
+// })

--- a/app/javascript/src/users/New.vue
+++ b/app/javascript/src/users/New.vue
@@ -29,27 +29,48 @@
   import axios from 'axios';
 
   export default {
-  name: 'New',
-  data() {
-    return {
-      user: {
-        name: '',
-        email: '',
-        password: '',
-        password_confirmation: '',
+
+    name: 'New',
+    data() {
+      return {
+        user: {
+          name: '',
+          email: '',
+          password: '',
+          password_confirmation: '',
+        }
+      }
+    },
+    methods: {
+      createUser: function () {
+        axios.post('/api/users', {
+          user: this.user
+        })
+        .then(response => {
+          this.$router.push({ path: '/'}),
+          this.$flashMessage.show({
+            type: 'success',
+            title: 'ユーザー登録が完了しました。',
+            text:'アカウント有効化メールを送信しました。',
+            time: 5000
+          });
+        })
+        .catch(err => {
+            this.$router.push({ path: '/users/new'}),
+            this.$flashMessage.show({
+              type: 'error',
+              title: 'ユーザー登録に失敗しました',
+              text: '入力内容に誤りがある可能性があります。',
+              time: 5000
+            });
+        })
+
+
+
+
       }
     }
-  },
-  methods: {
-    createUser: function () {
-      axios.post('/api/users', {
-        user: this.user })
-      .then((res) => {
-        this.$router.push({ path: '/'});
-      }, (error) => {
-        console.log(error);
-      });
-    }
+
   }
-}
+
 </script>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1562,6 +1562,14 @@
         }
       }
     },
+    "@smartweb/vue-flash-message": {
+      "version": "1.0.0-alpha.12",
+      "resolved": "https://registry.npmjs.org/@smartweb/vue-flash-message/-/vue-flash-message-1.0.0-alpha.12.tgz",
+      "integrity": "sha512-XHlDkSHaSxWEP2x+V2/IvEZ7eJYEG8VQEcadj8AgZcopOdSbVAF+I7HJ2neTfStGWY9Y/JF2jL3orbMwGhhq7g==",
+      "requires": {
+        "vue": "^3.0.0-0"
+      }
+    },
     "@types/http-proxy": {
       "version": "1.17.7",
       "resolved": "https://registry.npmjs.org/@types/http-proxy/-/http-proxy-1.17.7.tgz",
@@ -9934,6 +9942,14 @@
       "integrity": "sha512-sha6I8fx9HWtvTrFZfxZkiQQBpqSeT+UCwauYjkdOQYRvwsGwimlQQE2ayqUwuuXGzquFpCPoXzYKWlzL4OuXg==",
       "requires": {
         "@vue/devtools-api": "^6.0.0-beta.14"
+      }
+    },
+    "vuex": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/vuex/-/vuex-4.0.2.tgz",
+      "integrity": "sha512-M6r8uxELjZIK8kTKDGgZTYX/ahzblnzC4isU1tpmEuOIIKmV+TRdc+H4s8ds2NuZ7wpUTdGRzJRtoj+lI+pc0Q==",
+      "requires": {
+        "@vue/devtools-api": "^6.0.0-beta.11"
       }
     },
     "watchpack": {

--- a/package.json
+++ b/package.json
@@ -6,13 +6,15 @@
     "@rails/activestorage": "^6.0.0",
     "@rails/ujs": "^6.0.0",
     "@rails/webpacker": "^5.4.3",
+    "@smartweb/vue-flash-message": "^1.0.0-alpha.12",
     "@vue/babel-plugin-jsx": "^1.1.0",
     "@vue/compiler-sfc": "^3.2.19",
     "axios": "^0.22.0",
     "turbolinks": "^5.2.0",
     "vue": "^3.2.19",
     "vue-loader": "^16.8.1",
-    "vue-router": "^4.0.11"
+    "vue-router": "^4.0.11",
+    "vuex": "^4.0.2"
   },
   "version": "0.1.0",
   "devDependencies": {


### PR DESCRIPTION
vuex 及び vue-flash-messageをnpm install。flash message を表示するため当初vuexをインストールしたがpluginを使った方がフォルダやファイルを増やす必要がなかったので（フラッシュメッセージのcssはこだわる必要なしと考え）、そのようにした。vuexは今後使うことがあるかもしれないので残しておいた。
users/new  componentにpost 実行後、成功時はroot_pathにアクセス、フラッシュメッセージを表示、失敗時はusers/newをrender,フラッシュメッセージを表示するようにメソッド追加。