### PR TITLE
fix: add measures for csrf

### DIFF
--- a/app/controllers/api/sessions_controller.rb
+++ b/app/controllers/api/sessions_controller.rb
@@ -11,7 +11,7 @@ class Api::SessionsController < ApplicationController
         log_in user
         params[:session][:remember_me] == '1' ? remember(user) : forget(user)
         # flash[:success] = "ログインしました。"
-        # redirect_back_or root_url
+        # redirect_to root_url
       else
         # message = "有効化されていないアカウントです。"
         # message += "認証用メールを確認して有効化リンクをクリックしてください。"
@@ -29,9 +29,11 @@ class Api::SessionsController < ApplicationController
   end
 
   def destroy
-    log_out if logged_in?
-    # flash[:success] = "ログアウトしました。"
-    # redirect_to root_url
+    if logged_in?
+      log_out
+    else
+      response_bad_request
+    end
   end
 
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,5 +1,4 @@
 class ApplicationController < ActionController::Base
-  skip_before_action :verify_authenticity_token
   protect_from_forgery
   include SessionsHelper
 

--- a/app/javascript/src/components/Header.vue
+++ b/app/javascript/src/components/Header.vue
@@ -15,8 +15,7 @@
 </template>
 
 <script>
-
-
+  import axios from 'axios';
 
 export default {
   name: 'Header',
@@ -26,7 +25,7 @@ export default {
   },
   methods: {
      destroySession: function() {
-        axios.post('/api/logout')
+        axios.delete('/api/logout')
         .then(response => {
           this.$router.push({ path: '/'}),
           this.$flashMessage.show({
@@ -34,6 +33,12 @@ export default {
             title: 'ログアウト',
             text:'ログアウトしました',
             time: 5000
+          });
+        })
+        .catch(error => {
+          this.$flashMessage.show({
+            type: 'error',
+            text: 'ログアウトできませんでした。'
           });
         })
       }

--- a/app/javascript/src/password_resets/Edit.vue
+++ b/app/javascript/src/password_resets/Edit.vue
@@ -20,6 +20,7 @@
 <script>
   import axios from 'axios';
 
+
   export default {
 
     name: 'Change',
@@ -38,7 +39,7 @@
         user: this.user,
         email: this.email})
         .then(response => {
-          this.$router.push({ path: '/courses'}),
+          this.$router.push({ path: '/'}),
           this.$flashMessage.show({
             type: 'success',
             text:'パスワード再設定しました。',

--- a/app/javascript/src/sessions/New.vue
+++ b/app/javascript/src/sessions/New.vue
@@ -12,7 +12,7 @@
         <input type="password" v-model="session.password" class="pl-3 h-10 w-full border-solid border-2 rounded border-gray-600">
       </div>
       <div class="my-4">
-       
+
         <input type="checkbox" value="1" v-model="session.remember_me">
         <span>ログイン状態を保持する</span>
       </div>
@@ -30,6 +30,11 @@
 
 <script>
   import axios from 'axios';
+  axios.defaults.headers.common = {
+    'X-Requested-With': 'XMLHttpRequest',
+    'X-CSRF-TOKEN' : document.querySelector('meta[name="csrf-token"]').getAttribute('content')
+  };
+
 
   export default {
 
@@ -49,7 +54,7 @@
           session: this.session
         })
         .then(response => {
-          this.$router.push({ path: '/courses'}),
+          this.$router.push({ path: '/'}),
           this.$flashMessage.show({
             type: 'success',
             title: 'ログイン',

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -16,6 +16,9 @@
   </head>
 
   <body  class="bg-blue-900 flex flex-col min-h-screen">
+    <% if logged_in? %>
+      <p>test</p>
+    <% end %>
      <% flash.each do |message_type, message| %>
        <div class="<%= message_type %>"><%= message %></div>
      <% end %>

--- a/config/application.rb
+++ b/config/application.rb
@@ -9,7 +9,7 @@ Bundler.require(*Rails.groups)
 module SelftalkApp
   class Application < Rails::Application
     # Initialize configuration defaults for originally generated Rails version.
-  
+
     config.load_defaults 6.0
     config.active_record.default_timezone = :local
     config.i18n.default_locale = :ja
@@ -18,6 +18,8 @@ module SelftalkApp
     # Application configuration can go into files in config/initializers
     # -- all .rb files in that directory are automatically loaded after loading
     # the framework and any gems in your application.
+
+    
 
     config.generators do |g|
       g.test_framework :rspec,

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -25,7 +25,7 @@ Rails.application.routes.draw do
 
   namespace :api do
     post '/login', to: 'sessions#create'
-    post '/logout', to: 'sessions#destroy'
+    delete '/logout', to: 'sessions#destroy'
   end
   namespace :api do
     resources :password_resets, only: [:create, :edit, :update]


### PR DESCRIPTION
sessionが保存できない不具合の原因がcsrfに引っかかっていることとわかったので、コンポーネントに
axios.defaults.headers.common = {
    'X-Requested-With': 'XMLHttpRequest',
    'X-CSRF-TOKEN' : document.querySelector('meta[name="csrf-token"]').getAttribute('content')
  };

を追加。