### PR TITLE
fix: blank in password gets allowed

### DIFF
--- a/app/controllers/api/account_activations_controller.rb
+++ b/app/controllers/api/account_activations_controller.rb
@@ -4,11 +4,11 @@ class Api::AccountActivationsController < ApplicationController
     if user && !user.activated? && user.authenticated?(:activation, params[:id])
       user.activate
       log_in user
-      flash[:success] = "SelfTalkEnglishへようこそ！"
-      redirect_to root_path
+      # flash[:success] = "SelfTalkEnglishへようこそ！"
+      redirect_to user
     else
       flash[:danger] = "無効なリンクです。"
-      # redirect_to root_path
+      redirect_to root_path
       response_bad_request
     end
   end

--- a/app/controllers/static_pages_controller.rb
+++ b/app/controllers/static_pages_controller.rb
@@ -3,7 +3,6 @@ class StaticPagesController < ApplicationController
   include SessionsHelper
 
   def home
-    @user = current_user
   end
 
   def about

--- a/app/javascript/src/components/Header.vue
+++ b/app/javascript/src/components/Header.vue
@@ -29,11 +29,11 @@
     data() {
 
 
-      // let userId = document.getElementById('login').textContent
+      let userId = localStorage.getItem('Id')
 
       return {
 
-        UserId: 2
+        UserId: userId
 
       }
     },

--- a/app/javascript/src/router.js
+++ b/app/javascript/src/router.js
@@ -18,7 +18,7 @@ export const router = createRouter({
       component: Home,
     },
     {
-      path: '/users/1',
+      path: '/users/:id',
       name: 'show',
       component: Show,
     },

--- a/app/javascript/src/users/Show.vue
+++ b/app/javascript/src/users/Show.vue
@@ -24,9 +24,16 @@ export default {
   },
   methods: {
     setUser: function () {
-      axios.get('/api/users/1')
+      const id = this.$route.params.id
+      axios.get(`/api/users/${this.$route.params.id}`)
       .then(response => (
-        this.user = response.data
+        this.user = response.data,
+        localStorage.setItem('Id', id),
+        this.$flashMessage.show({
+            type: 'success',
+            text:'Welcome to SelfTalkEnglish',
+            time: 5000
+          })
       ))
     }
   }

--- a/app/views/api/users/edit.json.jbuilder
+++ b/app/views/api/users/edit.json.jbuilder
@@ -1,1 +1,1 @@
-json.(@user, :name , :email, :password, :password_confirmation)
+json.(@user, :name , :email)

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -17,7 +17,7 @@
 
   <body class="bg-blue-900 flex flex-col min-h-screen">
     <% if logged_in? %>
-      <p id="login" class="hidden"><%= @user.id %></p>
+      <p id="login" class="hidden"></p>
     <% end %>
 
 


### PR DESCRIPTION
ユーザ登録情報変更画面のパスワード欄が空白でもsubmitできるようfix。
ユーザーIDを取得するため、アカウント有効化後はshowアクションを実行し、そのURLに含まれるidをローカルストレージに保存することで実装。