### PR TITLE
fix: get user.id after singup and login

### DIFF
--- a/app/controllers/api/account_activations_controller.rb
+++ b/app/controllers/api/account_activations_controller.rb
@@ -4,12 +4,12 @@ class Api::AccountActivationsController < ApplicationController
     if user && !user.activated? && user.authenticated?(:activation, params[:id])
       user.activate
       log_in user
-      # flash[:success] = "SelfTalkEnglishへようこそ！"
-      redirect_to user
-    else
-      flash[:danger] = "無効なリンクです。"
+      flash.now[:success] = "SelfTalkEnglishへようこそ！"
       redirect_to root_path
-      response_bad_request
+    else
+      flash.now[:danger] = "無効なリンクです。"
+      redirect_to root_path
+
     end
   end
 end

--- a/app/controllers/api/password_resets_controller.rb
+++ b/app/controllers/api/password_resets_controller.rb
@@ -14,6 +14,7 @@ class Api::PasswordResetsController < ApplicationController
       @user.send_password_reset_email
       # flash[:success] = "パスワード再設定用のメールを送信しました。"
       # redirect_to root_url
+      render json: { id: @user.id }
     else
       # flash[:danger] = "未登録のメールアドレスです。"
       # render 'new'
@@ -32,6 +33,7 @@ class Api::PasswordResetsController < ApplicationController
     elsif @user.update(user_params)
       log_in @user
       @user.update_attribute(:reset_digest, nil)
+      render json: { id: @user.id }
       # flash[:success] = "パスワードを再設定しました。"
       # redirect_to root_url
     else

--- a/app/controllers/api/sessions_controller.rb
+++ b/app/controllers/api/sessions_controller.rb
@@ -5,14 +5,16 @@ class Api::SessionsController < ApplicationController
   end
 
   def create
-    user = User.find_by(email: params[:session][:email].downcase)
-    if user && user.authenticate(params[:session][:password])
-      if user.activated?
-        log_in user
+    @user = User.find_by(email: params[:session][:email].downcase)
+    if @user && @user.authenticate(params[:session][:password])
+      if @user.activated?
+        log_in @user
         # params[:session][:remember_me] == '1' ? remember(user) : forget(user)
         # flash[:success] = "ログインしました。"
-        remember(user)
+        remember(@user)
+        render json: { id: @user.id }
         # redirect_to root_url
+        
       else
         # message = "有効化されていないアカウントです。"
         # message += "認証用メールを確認して有効化リンクをクリックしてください。"

--- a/app/controllers/api/users_controller.rb
+++ b/app/controllers/api/users_controller.rb
@@ -16,6 +16,7 @@ class Api::UsersController < ApplicationController
     @user = User.new(user_params)
     if @user.save
       @user.send_activation_email
+      render json: { id: @user.id }
     else
       response_bad_request
     end

--- a/app/javascript/src/components/Header.vue
+++ b/app/javascript/src/components/Header.vue
@@ -19,8 +19,9 @@
 <script>
   import axios from 'axios';
 
+  let userId = localStorage.getItem('Id')
 
- export default {
+  export default {
    name: 'Header',
     props: {
       nav1: String,
@@ -29,7 +30,6 @@
     data() {
 
 
-      let userId = localStorage.getItem('Id')
 
       return {
 
@@ -50,6 +50,7 @@
           axios.delete('/api/logout')
           .then(response => {
             this.$store.commit('logout'),
+            localStorage.removeItem('Id'),
             this.$router.push({ path: '/'}),
             this.$flashMessage.show({
               type: 'success',

--- a/app/javascript/src/password_resets/Edit.vue
+++ b/app/javascript/src/password_resets/Edit.vue
@@ -40,6 +40,8 @@
         user: this.user,
         email: this.email})
         .then(response => {
+          const id = response.data.id
+          localStorage.setItem('Id', id),
           this.$store.commit('login', token),
           this.$router.push({ path: '/'}),
           this.$flashMessage.show({

--- a/app/javascript/src/password_resets/New.vue
+++ b/app/javascript/src/password_resets/New.vue
@@ -31,6 +31,12 @@
           password_reset: this.password_reset
         })
         .then(response => {
+          const userId = localStorage.getItem('Id')
+          if (userId) {
+            localStorage.removeItem('Id')
+          }
+          const id = response.data.id
+          localStorage.setItem('Id', id),
           this.$router.push({ path: '/'}),
           this.$flashMessage.show({
             type: 'success',

--- a/app/javascript/src/sessions/New.vue
+++ b/app/javascript/src/sessions/New.vue
@@ -49,6 +49,12 @@
           session: this.session
         })
         .then(response => {
+           const userId = localStorage.getItem('Id')
+          if (userId) {
+            localStorage.removeItem('Id')
+          }
+          const id = response.data.id
+          localStorage.setItem('Id', id),
           this.$store.commit('login', token),
           this.$router.push({ path: '/'}),
           this.$flashMessage.show({

--- a/app/javascript/src/users/New.vue
+++ b/app/javascript/src/users/New.vue
@@ -52,6 +52,12 @@
           user: this.user
         })
         .then(response => {
+          const userId = localStorage.getItem('Id')
+          if (userId) {
+            localStorage.removeItem('Id')
+          }
+          const id = response.data.id
+          localStorage.setItem('Id', id),
           this.$router.push({ path: '/'}),
           this.$flashMessage.show({
             type: 'success',

--- a/app/javascript/src/users/Show.vue
+++ b/app/javascript/src/users/Show.vue
@@ -24,17 +24,10 @@ export default {
   },
   methods: {
     setUser: function () {
-      const id = this.$route.params.id
       axios.get(`/api/users/${this.$route.params.id}`)
-      .then(response => (
-        this.user = response.data,
-        localStorage.setItem('Id', id),
-        this.$flashMessage.show({
-            type: 'success',
-            text:'Welcome to SelfTalkEnglish',
-            time: 5000
-          })
-      ))
+      .then(response => {
+        this.user = response.data
+      })
     }
   }
 }

--- a/spec/requests/api/account_activation_request_spec.rb
+++ b/spec/requests/api/account_activation_request_spec.rb
@@ -10,9 +10,8 @@ RSpec.describe "Api::AccountActivations", type: :request do
         email: 'wrong')
     end
 
-    it "ログインに失敗し、エラー400を返す" do
+    it "ログインに失敗する" do
       expect(is_logged_in?).to be_falsy
-      expect(response).to  have_http_status "400"
     end
   end
 

--- a/spec/requests/api/password_resets_request_spec.rb
+++ b/spec/requests/api/password_resets_request_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe "Api::PasswordResets", type: :request do
       it "レスポンス204を返す" do
         post '/api/password_resets', params: {password_reset: {email: user.email}}
         expect(ActionMailer::Base.deliveries.size).to eq(1)
-        expect(response).to have_http_status "204"
+        expect(response).to have_http_status "200"
       end
     end
   end
@@ -55,7 +55,7 @@ RSpec.describe "Api::PasswordResets", type: :request do
                    password: "password",
                    password_confirmation: "password" }}
           expect(is_logged_in?).to be_truthy
-          expect(response).to have_http_status "204"
+          expect(response).to have_http_status "200"
       end
     end
   end
@@ -84,7 +84,7 @@ RSpec.describe "Api::PasswordResets", type: :request do
                    password_confirmation: "foobar" }}
           expect(is_logged_in?).to be_truthy
           expect(user.reload.reset_digest).to eq nil
-          expect(response).to have_http_status "204"
+          expect(response).to have_http_status "200"
         end
       end
     end

--- a/spec/requests/api/sessions_request_spec.rb
+++ b/spec/requests/api/sessions_request_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 
 RSpec.describe "Api::Sessions", type: :request do
   let(:user){create(:user)}
-  
+
   describe "post/ login_path" do
     it "不正な入力情報に対しログインに失敗する" do
       post '/api/login', params: { session: { email: "invalid@example.com",
@@ -13,7 +13,7 @@ RSpec.describe "Api::Sessions", type: :request do
     it "有効な入力情報に対しログインに成功する" do
       post '/api/login', params: { session: { email: user.email,
       password: 'password' } }
-      expect(response).to have_http_status "204"
+      expect(response).to have_http_status "200"
     end
 
     it "ログイン後クッキーを保存する" do

--- a/spec/requests/api/users_request_spec.rb
+++ b/spec/requests/api/users_request_spec.rb
@@ -22,12 +22,12 @@ RSpec.describe "Api::Users", type: :request do
           password_confirmation: "password" } }
         }.to change(User, :count).by(1)
       expect(ActionMailer::Base.deliveries.size).to eq(1)
-      expect(response).to have_http_status "204"
+      expect(response).to have_http_status "200"
 
     end
   end
 
-  
+
   # describe "get/ edit_user_path" do
   #   context "ログイン済みユーザーのアクセス" do
   #     it "redirects to edit_user_path" do


### PR DESCRIPTION
signup, login, password_reset後にrender jsonメソッドを追加してuser.idをローカルストレージに保存できるよう実装。ログアウトもしくは格postアクション前に保存されたローカルストレージがあれば削除するよう実装。
上記に合わせてrspecを変更。