### PR TITLE
fix: change rooting after account activation

### DIFF
--- a/app/controllers/api/account_activations_controller.rb
+++ b/app/controllers/api/account_activations_controller.rb
@@ -3,11 +3,8 @@ class Api::AccountActivationsController < ApplicationController
     user = User.find_by(email: params[:email])
     if user && !user.activated? && user.authenticated?(:activation, params[:id])
       user.activate
-      log_in user
-      flash.now[:success] = "SelfTalkEnglishへようこそ！"
       redirect_to root_path
     else
-      flash.now[:danger] = "無効なリンクです。"
       redirect_to root_path
 
     end

--- a/app/controllers/api/password_resets_controller.rb
+++ b/app/controllers/api/password_resets_controller.rb
@@ -14,7 +14,7 @@ class Api::PasswordResetsController < ApplicationController
       @user.send_password_reset_email
       # flash[:success] = "パスワード再設定用のメールを送信しました。"
       # redirect_to root_url
-      render json: { id: @user.id }
+      # render json: { id: @user.id }
     else
       # flash[:danger] = "未登録のメールアドレスです。"
       # render 'new'

--- a/app/controllers/api/users_controller.rb
+++ b/app/controllers/api/users_controller.rb
@@ -16,7 +16,6 @@ class Api::UsersController < ApplicationController
     @user = User.new(user_params)
     if @user.save
       @user.send_activation_email
-      render json: { id: @user.id }
     else
       response_bad_request
     end
@@ -27,8 +26,6 @@ class Api::UsersController < ApplicationController
 
   def update
     if @user.update(user_params)
-      # flash[:success] = "登録情報を変更しました。"
-      # redirect_to root_url
     else
       response_bad_request
     end

--- a/app/javascript/home_page/header.js
+++ b/app/javascript/home_page/header.js
@@ -1,7 +1,7 @@
 'user strict';
 {
   document.addEventListener("DOMContentLoaded", () => {
-
+    
     const tab = document.getElementById('tab')
     const menu = document.getElementById('menu')
     document.addEventListener("click", (e) => {

--- a/app/javascript/src/components/Header.vue
+++ b/app/javascript/src/components/Header.vue
@@ -1,11 +1,17 @@
 <template>
   <header class="bg-blue-900 text-white h-16 border-b-2 border-fuchsia-600">
     <router-link to="/" class="font-serif text-3xl ">SelfTalkEnglish</router-link>
-    <nav class="float-right flex flex-row text-white font-bold mt-4 mr-10 ">
-      <div v-if="$store.state.loggedIn">
-        <span @click="destroySession" class="mr-4 hover:bg-blue-300 cursor-pointer">ログアウト
-        </span>
-        <router-link :to="{ name: 'change info', params: { id: $store.state.userId}}" class="mr-4 hover:bg-blue-300">登録情報を変更する</router-link>
+    <nav class="float-right flex flex-row text-white font-bold mt-4 mr-10">
+      <div v-if="$store.state.loggedIn" class="float-right flex flex-row">
+        <router-link :to="{name: 'show', params: {id: $store.state.userId}}" class="mr-4 hover:bg-blue-300">マイページ</router-link>
+        <ul>
+          <li id="menu" class="hover:bg-blue-300 cursor-pointer">メニュー▼</li>
+          <div id="tab" class="absolute right-4 p-2 w-1/6 bg-blue-900 font-thin border border-solid border-white rounded hidden">
+            <li @click="destroySession" class="mr-4 hover:bg-blue-300 cursor-pointer">ログアウト
+            </li>
+            <router-link :to="{ name: 'change info', params: { id: $store.state.userId}}" class="mr-4 hover:bg-blue-300">登録情報を変更する</router-link>
+          </div>
+        </ul>
       </div>
       <div v-else>
         <router-link to="/login" class="mr-4 hover:bg-blue-300">{{nav1}}</router-link>
@@ -19,7 +25,7 @@
 <script>
   import axios from 'axios';
 
-  let userId = localStorage.getItem('Id')
+  // const userId = localStorage.getItem('Id')
 
   export default {
    name: 'Header',
@@ -27,16 +33,16 @@
       nav1: String,
       nav2: String
     },
-    data() {
+    // data() {
 
 
 
-      return {
+    //   return {
 
-        UserId: userId
+    //     UserId: userId
 
-      }
-    },
+    //   }
+    // },
     created() {
       if(document.body.contains(document.getElementById('login'))) {
         const token = Math.random().toString(32).substring(2)
@@ -44,14 +50,17 @@
       } else {
         this.$store.commit('logout');
       }
-
+    },
+    mounted() {
+      this.showMenu();
     },
     methods: {
       destroySession: function() {
           axios.delete('/api/logout')
           .then(response => {
             this.$store.commit('logout'),
-            localStorage.removeItem('Id'),
+            // localStorage.removeItem('Id'),
+            this.$store.commit('removeId'),
             this.$router.push({ path: '/'}),
             this.$flashMessage.show({
               type: 'success',
@@ -66,7 +75,19 @@
               text: 'ログアウトできませんでした。'
             });
           })
+        },
+      showMenu: function() {
+
+        const tab = document.getElementById('tab')
+        const menu = document.getElementById('menu')
+        document.addEventListener("click", (e) => {
+        if(e.target.closest("#menu")) {
+          tab.classList.contains("hidden") ? tab.classList.remove("hidden") : tab.classList.add("hidden");
+        }else {
+          tab.classList.add("hidden");
         }
+        });
+      }
     }
   }
 </script>

--- a/app/javascript/src/password_resets/Edit.vue
+++ b/app/javascript/src/password_resets/Edit.vue
@@ -41,7 +41,7 @@
         email: this.email})
         .then(response => {
           const id = response.data.id
-          localStorage.setItem('Id', id),
+          this.$store.commit('setId', id),
           this.$store.commit('login', token),
           this.$router.push({ path: '/'}),
           this.$flashMessage.show({

--- a/app/javascript/src/password_resets/New.vue
+++ b/app/javascript/src/password_resets/New.vue
@@ -31,12 +31,7 @@
           password_reset: this.password_reset
         })
         .then(response => {
-          const userId = localStorage.getItem('Id')
-          if (userId) {
-            localStorage.removeItem('Id')
-          }
-          const id = response.data.id
-          localStorage.setItem('Id', id),
+          this.$store.commit('setId', id),
           this.$router.push({ path: '/'}),
           this.$flashMessage.show({
             type: 'success',

--- a/app/javascript/src/sessions/New.vue
+++ b/app/javascript/src/sessions/New.vue
@@ -49,10 +49,6 @@
           session: this.session
         })
         .then(response => {
-          const userId = localStorage.getItem('Id')
-          if (userId) {
-            localStorage.removeItem('Id')
-          }
           const id = response.data.id
           this.$store.commit('setId', id),
           this.$store.commit('login', token),

--- a/app/javascript/src/store.js
+++ b/app/javascript/src/store.js
@@ -19,8 +19,11 @@ export const store = createStore ({
       state.loggedIn = false;
     },
     setId: (state, id) => {
-      localStorage.setItem('Id', id)
+      // localStorage.setItem('Id', id)
       state.userId = id
+    },
+    removeId: (state) => {
+      state.userId = 0
     }
   },
   plugins : [

--- a/app/javascript/src/users/Edit.vue
+++ b/app/javascript/src/users/Edit.vue
@@ -39,9 +39,6 @@
     data() {
       return {
         user:
-          // password: "",
-          // password_confirmation: "",
-          // id: this.$route.params.id
           "users"
 
       }

--- a/app/javascript/src/users/New.vue
+++ b/app/javascript/src/users/New.vue
@@ -52,12 +52,6 @@
           user: this.user
         })
         .then(response => {
-          const userId = localStorage.getItem('Id')
-          if (userId) {
-            localStorage.removeItem('Id')
-          }
-          const id = response.data.id
-          localStorage.setItem('Id', id),
           this.$router.push({ path: '/'}),
           this.$flashMessage.show({
             type: 'success',

--- a/spec/requests/api/account_activation_request_spec.rb
+++ b/spec/requests/api/account_activation_request_spec.rb
@@ -10,8 +10,11 @@ RSpec.describe "Api::AccountActivations", type: :request do
         email: 'wrong')
     end
 
-    it "ログインに失敗する" do
-      expect(is_logged_in?).to be_falsy
+    it "ログイン時にエラー401を返す" do
+      expect(response).to redirect_to root_path
+      post '/api/login', params: { session: { email: user.email,
+      password: 'password' } }
+      expect(response).to have_http_status "401"
     end
   end
 
@@ -24,9 +27,11 @@ RSpec.describe "Api::AccountActivations", type: :request do
     end
 
 
-    it "ログインに成功してルートURLにアクセスする" do
-      expect(is_logged_in?).to be_truthy
+    it "ログインに成功する" do
       expect(response).to redirect_to root_path
+      post '/api/login', params: { session: { email: user.email,
+        password: 'password' } }
+        expect(response).to have_http_status "200"
     end
   end
 

--- a/spec/requests/api/password_resets_request_spec.rb
+++ b/spec/requests/api/password_resets_request_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe "Api::PasswordResets", type: :request do
       it "レスポンス204を返す" do
         post '/api/password_resets', params: {password_reset: {email: user.email}}
         expect(ActionMailer::Base.deliveries.size).to eq(1)
-        expect(response).to have_http_status "200"
+        expect(response).to have_http_status "204"
       end
     end
   end

--- a/spec/requests/api/users_request_spec.rb
+++ b/spec/requests/api/users_request_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe "Api::Users", type: :request do
           password_confirmation: "password" } }
         }.to change(User, :count).by(1)
       expect(ActionMailer::Base.deliveries.size).to eq(1)
-      expect(response).to have_http_status "200"
+      expect(response).to have_http_status "204"
 
     end
   end

--- a/spec/support/test_helper.rb
+++ b/spec/support/test_helper.rb
@@ -5,7 +5,7 @@ module TestHelper
 
 
   def log_in_as(user, remember_me: '1')
-    post login_path, params: { session: {
+    post '/api/login', params: { session: {
       email: user.email,
       password: user.password,
       remember_me: remember_me,
@@ -13,7 +13,7 @@ module TestHelper
   end
 
   def log_in(user)
-    visit login_path
+    visit api_login_path
     fill_in 'メールアドレス', with: user.email
     fill_in 'パスワード', with: user.password
     click_button 'ログイン'


### PR DESCRIPTION
account activation後はログインせず、ルートURLにアクセスされるよう動作変更。account有効化メールのリンクをクリックする前にログインを実行したり、別のアカウントを登録したときにユーザーidの取得でエラーが起きることを回避。
上記変更に合わせてrspecも変更。