### PR TITLE
マイページ上に日付ごとのanswersを表示

### DIFF
--- a/app/controllers/api/users_controller.rb
+++ b/app/controllers/api/users_controller.rb
@@ -7,6 +7,14 @@ class Api::UsersController < ApplicationController
   end
 
   def show
+    @user = current_user
+    @dates = current_user.answers.map{|dates| dates.created_at.to_date}.uniq
+    
+    # @dates = Kaminari.paginate_array(@dates).page(params[:page]).per(5)
+    # @learning_days = @dates.count
+    # @wdays = ['Mon','Tue','Wed','Thu','Fri','Sat','Sun']
+    # @contributions = current_user.answers.where(created_at: Time.current.all_week)
+    # @contributions = @contributions.map{|days| days.created_at.strftime('%a')}
   end
 
   def new

--- a/app/javascript/src/users/Show.vue
+++ b/app/javascript/src/users/Show.vue
@@ -1,8 +1,14 @@
 <template>
   <div>
-    <div>
-        <p>{{user.name}}</p>
-        <p>{{user.email}}</p>
+    <h1 class="text-center text-3xl text-white font-bold pb-5">{{user.name}}さんの学習記録</h1>
+    <div class="text-center flex items-center justify-center">
+      <div v-for="date in dates" class="mt-4" :key="date">
+        <li class="w-56 bg-white list-none underline text-black mt-5 font-bold text-2xl
+                 border border-solid border-white rounded-full hover:bg-black hover:text-white">
+         {{date}}
+        </li>
+      </div>
+
     </div>
 
   </div>
@@ -16,7 +22,8 @@ export default {
   name: 'Show',
   data: function () {
     return {
-      user: "user"
+      user: "",
+      dates: ""
     }
   },
   mounted() {
@@ -27,6 +34,8 @@ export default {
       axios.get(`/api/users/${this.$route.params.id}`)
       .then(response => {
         this.user = response.data
+        this.dates = response.data.dates
+        console.log(response.data);
       })
     }
   }

--- a/app/views/api/users/show.json.jbuilder
+++ b/app/views/api/users/show.json.jbuilder
@@ -1,1 +1,6 @@
 json.(@user, :name , :email, :password, :password_confirmation)
+
+json.dates do
+  json.array! @dates
+end
+

--- a/spec/requests/api/users_request_spec.rb
+++ b/spec/requests/api/users_request_spec.rb
@@ -4,6 +4,18 @@ RSpec.describe "Api::Users", type: :request do
   let(:user){create(:user)}
   let(:other_user){create(:user)}
 
+  describe "show/ user_path" do
+    let!(:answer){create(:answer)}
+      before do
+        log_in_as user
+      end
+
+    it "成功レスポンス200を返す" do
+      get api_user_path(user)
+      expect(response).to have_http_status "200"
+    end
+  end
+
   describe "post/ signup_path " do
     it "不正な入力情報に対してエラー400を返す" do
       post '/api/users', params: { user: { name:  "",


### PR DESCRIPTION
## 変更の概要

* users/show componentにユーザーの名前、そのユーザーのanswersを表示するよう実装。
* api/users/showが正常にアクセスされることをテストするrspecを追加。
* 例えば10/25と10/26に保存した回答があれば「2021-10-25」と「2021-10-26」が表示される。


## なぜこの変更をするのか

* 基本機能追加


## やったこと

* [x] やったこと：
* api/users_controllerにshowアクションを追加（current_userとそのuserのanswerの作成日付を配列として保存するインスタンス変数を返す）。
* users/Show.vueにv-forを用いて日付集を表示するテンプレートを作成。
* api/users/showアクセスして成功レスポンス200を返すことをテストするrspecを追加


