### PR TITLE
【fix】マイページ上のanswers/indexへのリンクのデバッグ

### DIFF
--- a/app/javascript/src/answers/Index.vue
+++ b/app/javascript/src/answers/Index.vue
@@ -26,7 +26,11 @@
     },
     methods: {
       getAnswers: function() {
-        axios.get('api/answers')
+        axios.get('api/answers', {
+          params: {
+            created_at: this.$route.query.created_at
+          }
+        })
         .then(response => {
           this.answers = response.data
           console.log(response.data);

--- a/app/javascript/src/users/Show.vue
+++ b/app/javascript/src/users/Show.vue
@@ -1,9 +1,9 @@
 <template>
   <div>
     <h1 class="text-center text-3xl text-white font-bold pb-5">{{user.name}}さんの学習記録</h1>
-    <div class="text-center flex items-center justify-center">
-      <div v-for="date in dates" class="mt-4" :key="date">
-        <router-link :to="{name: 'answers', params: {created_at: date}}"
+    <div class="text-center flex flex-col items-center justify-center">
+      <div v-for="date in dates" class="mt-8" :key="date">
+        <router-link :to="{name: 'answers', query: {created_at: date}}"
         class="p-2 bg-white list-none underline text-black mt-5 font-bold text-2xl
                  border border-solid border-white rounded-full hover:bg-black hover:text-white">
          {{date}}

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -32,6 +32,6 @@
      <% end %>
      <%= yield %>
     </div>
-    <%= render 'layouts/footer' %>-->
+    <%= render 'layouts/footer' %>
   </body>
 </html>


### PR DESCRIPTION
## 変更の概要

* マイページ上のanswers/indexへのリンクにそれぞれの日付のクエリパラメータを付与
* answers/index componentアクセス時にaxios.getする情報の中にcretaed_at paramsを付与

## なぜこの変更をするのか

* 2021-10-26及び2021-10-27それぞれ日付に作成されたanswersのみを表示できるようにするはずがそのユーザー全てのanswersを取得しまうエラーが発生していた。

## やったこと

* [x]　users/show componentのリンクにクエリパラメーターの記述追加。
* answers/index componentのgetAnswers methodでaxios.getする際にURLのcreated_at クエリパラーメータをparamsとしてanswers_controllerに送信するよう記述追加。