### PR TITLE
ユーザーの学習記録表示機能

### DIFF
--- a/app/controllers/api/users_controller.rb
+++ b/app/controllers/api/users_controller.rb
@@ -9,12 +9,13 @@ class Api::UsersController < ApplicationController
   def show
     @user = current_user
     @dates = current_user.answers.map{|dates| dates.created_at.to_date}.uniq
-    
+    @learning_days = @dates.count
+    @wdays = ['Mon','Tue','Wed','Thu','Fri','Sat','Sun']
+    @contributions = current_user.answers.where(created_at: Time.current.all_week)
+    @contributions = @contributions.map{|days| days.created_at.strftime('%a')}
+
+  
     # @dates = Kaminari.paginate_array(@dates).page(params[:page]).per(5)
-    # @learning_days = @dates.count
-    # @wdays = ['Mon','Tue','Wed','Thu','Fri','Sat','Sun']
-    # @contributions = current_user.answers.where(created_at: Time.current.all_week)
-    # @contributions = @contributions.map{|days| days.created_at.strftime('%a')}
   end
 
   def new

--- a/app/javascript/src/users/Show.vue
+++ b/app/javascript/src/users/Show.vue
@@ -1,6 +1,22 @@
 <template>
   <div>
     <h1 class="text-center text-3xl text-white font-bold pb-5">{{user.name}}さんの学習記録</h1>
+
+    <!-- 学習記録・contributions -->
+    <div class="text-white">
+      <p class="ml-4">学習日数</p>
+      <section class="w-24 h-24 pt-8 mb-4 text-center object-cover border border-solid border-white rounded-full">
+      {{learningDays}}日</section>
+
+      <p>今週の学習状況</p>
+      <section v-for="day in days" :key="day">
+        <span>{{day}}</span>
+        <progress :value="contributions.filter(n => n === day).length" max="30" class="absolute w-32 ml-10 mt-1 border border-solid border-white h-4"></progress>
+         <span>{{contributions.filter(n => n === day).length}}</span>
+      </section>
+    </div>
+
+    <!-- answersリンク集（日付ごとに集計） -->
     <div class="text-center flex flex-col items-center justify-center">
       <div v-for="date in dates" class="mt-8" :key="date">
         <router-link :to="{name: 'answers', query: {created_at: date}}"
@@ -24,7 +40,10 @@ export default {
   data: function () {
     return {
       user: "",
-      dates: ""
+      dates: "",
+      learningDays: "",
+      days: "",
+      contributions: ""
     }
   },
   mounted() {
@@ -36,6 +55,10 @@ export default {
       .then(response => {
         this.user = response.data
         this.dates = response.data.dates
+        this.learningDays = response.data.learning
+        this.days = response.data.days
+        this.dates = response.data.dates
+        this.contributions = response.data.contributions
       })
     }
   }

--- a/app/views/api/users/show.json.jbuilder
+++ b/app/views/api/users/show.json.jbuilder
@@ -1,6 +1,15 @@
 json.(@user, :name , :email, :password, :password_confirmation)
 
+json.learning @learning_days
+
 json.dates do
   json.array! @dates
 end
 
+json.days do
+  json.array! @wdays
+end
+
+json.contributions do
+  json.array! @contributions
+end


### PR DESCRIPTION
## 変更の概要

* マイページにユーザーのanswer以外の学習記録を表示されるように実装

## なぜこの変更をするのか

* 基本機能につき割愛

## やったこと

* [x] api/users_controller showアクションでanswerを作成した日数、一週間の曜日、直近一週間に保存されたanswersの数を曜日として保存した変数を返すよう追加
* Show.vueで上記３点のインスタンス変数をresponse.dataとして受け取り、テンプレートに返されるよう実装。
* v-forとjavascript のメソッドをテンプレートに埋め込み、各曜日に保存されたanswerの数をプログレスバーとして表示されるよう実装
* [ ] やっていること
* cssによるデザイン