### PR TITLE
管理者ユーザ用リンク作成

### DIFF
--- a/app/javascript/src/components/Header.vue
+++ b/app/javascript/src/components/Header.vue
@@ -10,6 +10,11 @@
             <li @click="destroySession" class="mr-4 hover:bg-blue-300 cursor-pointer">ログアウト
             </li>
             <router-link :to="{ name: 'change info', params: { id: $store.state.userId}}" class="mr-4 hover:bg-blue-300">登録情報を変更する</router-link>
+            <li v-if="$store.state.admin" class="flex flex-col">
+              <router-link to="/questions/new" class="mr-4 hover:bg-blue-300" >
+              問題作成</router-link>
+              <router-link to="/questions" class="mr-4 hover:bg-blue-300">問題一覧</router-link>
+            </li>
           </div>
         </ul>
       </div>

--- a/app/javascript/src/questions/Index.vue
+++ b/app/javascript/src/questions/Index.vue
@@ -1,0 +1,20 @@
+<template>
+  <div class="text-center items-center justify-center">
+    <p>Index question</p>
+
+  </div>
+
+</template>
+
+<script>
+  import axios from 'axios';
+
+  export default {
+    name: 'Questions'
+  }
+
+
+
+
+
+</script>

--- a/app/javascript/src/questions/New.vue
+++ b/app/javascript/src/questions/New.vue
@@ -1,0 +1,20 @@
+<template>
+  <div class="text-center items-center justify-center">
+    <p>New question</p>
+
+  </div>
+
+</template>
+
+<script>
+  import axios from 'axios';
+
+  export default {
+    name: 'QuestionNew'
+  }
+
+
+
+
+
+</script>

--- a/app/javascript/src/router.js
+++ b/app/javascript/src/router.js
@@ -9,6 +9,8 @@ import userEdit from './users/Edit.vue'
 import Courses from './answers/New.vue'
 import Answers from './answers/Index.vue'
 import AnswerEdit from './answers/Edit.vue'
+import Questions from './questions/Index.vue'
+import QuestionNew from './questions/New.vue'
 
 
 
@@ -70,6 +72,16 @@ export const router = createRouter({
       path: '/answers/:id/edit',
       name: 'answerEdit',
       component: AnswerEdit
+    },
+    {
+      path: '/questions/new',
+      name: 'questionNew',
+      component: QuestionNew
+    },
+    {
+      path: '/questions',
+      name: 'questions',
+      component: Questions
     }
   ],
 })

--- a/app/javascript/src/sessions/New.vue
+++ b/app/javascript/src/sessions/New.vue
@@ -51,7 +51,10 @@
         .then(response => {
           const id = response.data.id
           this.$store.commit('setId', id),
-          this.$store.commit('login', token),
+          this.$store.commit('login', token)
+          if(id == 1) {
+            this.$store.commit('admin')
+          }
           this.$router.push({ path: '/'}),
           this.$flashMessage.show({
             type: 'success',

--- a/app/javascript/src/store.js
+++ b/app/javascript/src/store.js
@@ -6,6 +6,7 @@ export const store = createStore ({
   state() {
     return {
       loggedIn: false,
+      admin: false,
       userId: 0,
     }
   },
@@ -17,6 +18,7 @@ export const store = createStore ({
     logout: (state)=> {
       localStorage.removeItem('Token');
       state.loggedIn = false;
+      state.admin = false;
     },
     setId: (state, id) => {
       state.userId = id
@@ -24,6 +26,9 @@ export const store = createStore ({
     removeId: (state) => {
       state.userId = 0
     },
+    admin: (state) => {
+      state.admin = true
+    }
 
   },
   plugins : [


### PR DESCRIPTION
## 変更の概要

* 管理者ユーザー用のリンクを作成し、そのユーザーにだけリンクがメニューからアクセスできるよう実装

## なぜこの変更をするのか

* 基本機能につき割愛

## やったこと

* [x] store.jsにadminユーザーのログイン状態を識別できるよう、admin: falseを設定し、mutationでtrueにできるよう記載追加。
* store.jsのlogaout mutationにadminをfalseにする記述を追加。
*sessions/New.vue のログインメソッドにログインしたユーザーのidが１であるならばstore.jsのadmin mutationを実行し、admin: trueになるよう記述追加。
*出題文を作成するコンポーネントと一覧を表示するコンポーネントの雛形をルーターに設定。
*ヘッダーのメニューにadmin: trueであるならば上記２つのコンポーネントのリンクを表示するよう実装。