### PR TITLE
問題一覧表示コンポーネント

### DIFF
--- a/app/controllers/api/questions_controller.rb
+++ b/app/controllers/api/questions_controller.rb
@@ -1,9 +1,11 @@
 class Api::QuestionsController < ApplicationController
-  # before_action :admined_user
+  before_action :admined_user
 
   def index
+
     @questions = Question.where(mode_num: params[:mode_num])
-    @questions = Kaminari.paginate_array(@questions).page(params[:page]).per(5)
+    render json: @questions
+    # @questions = Kaminari.paginate_array(@questions).page(params[:page]).per(5)
   end
 
   def show
@@ -30,7 +32,6 @@ class Api::QuestionsController < ApplicationController
 
   def destroy
     Question.find(params[:id]).destroy
-    redirect_to questions_path
   end
 
   private

--- a/app/controllers/questions_controller.rb
+++ b/app/controllers/questions_controller.rb
@@ -2,8 +2,8 @@ class QuestionsController < ApplicationController
   before_action :admined_user
 
   def index
-    @questions = Question.where(mode_num: params[:mode_num])
-    @questions = Kaminari.paginate_array(@questions).page(params[:page]).per(5)
+    # @questions = Question.where(mode_num: params[:mode_num])
+    # @questions = Kaminari.paginate_array(@questions).page(params[:page]).per(5)
 
   end
 

--- a/app/javascript/src/answers/Index.vue
+++ b/app/javascript/src/answers/Index.vue
@@ -33,7 +33,6 @@
         })
         .then(response => {
           this.answers = response.data
-          console.log(response.data);
         })
       }
     }

--- a/app/javascript/src/components/Header.vue
+++ b/app/javascript/src/components/Header.vue
@@ -13,7 +13,7 @@
             <li v-if="$store.state.admin" class="flex flex-col">
               <router-link to="/questions/new" class="mr-4 hover:bg-blue-300" >
               問題作成</router-link>
-              <router-link to="/questions" class="mr-4 hover:bg-blue-300">問題一覧</router-link>
+              <router-link :to="{ name: 'questions', query: {mode_num: 1}}" class="mr-4 hover:bg-blue-300">問題一覧</router-link>
             </li>
           </div>
         </ul>

--- a/app/javascript/src/pages/Home.vue
+++ b/app/javascript/src/pages/Home.vue
@@ -47,7 +47,7 @@
 <script>
   export default {
     name: 'Home',
-   
+
 
 
 

--- a/app/javascript/src/questions/Index.vue
+++ b/app/javascript/src/questions/Index.vue
@@ -1,7 +1,25 @@
 <template>
-  <div class="text-center items-center justify-center">
-    <p>Index question</p>
+  <div class="text-center text-white">
+    <div class="flex flex-row mb-10">
+     <p class="mt-2">出題モード一覧▶︎</p>
+     <div class="flex flex-row">
+       <router-link :to="{ name: 'questions', query: {mode_num: 1}}" @click="showQuestions">
+         <img src="/assets/explain.svg" class="ml-4 w-12 h-12 object-cover border border-solid border-white rounded-full hover:bg-white">
+       </router-link>
+       <router-link :to="{ name: 'questions', query: {mode_num: 2}}" @click="showQuestions">
+         <img src="/assets/reaction.svg" class="ml-4 w-12 h-12 object-cover border border-solid border-white rounded-full hover:bg-white">
+       </router-link>
+     </div>
+    </div>
 
+    <ul class="mb-8 text-2xl">
+      <li>{{courseTitle}}</li>
+    </ul>
+
+    <div v-for="question in questions" class="mx-auto pt-1 h-12 w-1/2 bg-white text-2xl text-black m-4 border border-solid border-black rounded" :key="question">
+      <li class="list-none">{{question.content}}
+       <button @click="deleteQuestion(question.id)" class="underline mr-4 float-right  hover:text-blue-300 ">削除</button></li>
+    </div>
   </div>
 
 </template>
@@ -10,7 +28,51 @@
   import axios from 'axios';
 
   export default {
-    name: 'Questions'
+    name: 'Questions',
+    data() {
+      return {
+        questions: "",
+        courseTitle: "Self Explain問題集"
+
+      }
+    },
+    mounted() {
+      this.showQuestions();
+    },
+    methods: {
+      showQuestions: function() {
+        axios.get('/api/questions', {
+          params: {
+            mode_num: this.$route.query.mode_num
+          }
+        })
+        .then(response => {
+          this.questions = response.data
+          if(this.$route.query.mode_num == 1) {
+            this.courseTitle = "Self Explain問題集"
+          } if(this.$route.query.mode_num == 2) {
+            this.courseTitle = "Self Reaction問題集"
+          }
+        })
+      },
+      deleteQuestion: function(id) {
+        axios.delete('/api/questions/' + id)
+        .then(response => {
+          this.$flashMessage.show({
+            type: 'success',
+            text:'問題を削除しました',
+            time: 5000
+          })
+        .catch(err => {
+            this.$flashMessage.show({
+              type: 'error',
+              text: '削除に失敗しました',
+              time: 5000
+            });
+        })
+      })
+     }
+   }
   }
 
 

--- a/app/views/questions/index.html.erb
+++ b/app/views/questions/index.html.erb
@@ -1,4 +1,6 @@
-<%= provide(:title, "問題一覧") %>
+<%
+=begin%>
+ <%= provide(:title, "問題一覧") %>
 
 <div class="text-center text-white">
   <div class="flex flex-row mb-10">
@@ -30,3 +32,5 @@
   </div>
 
 </div>
+<%
+=end%>


### PR DESCRIPTION
## 変更の概要

*管理者ユーザー用の出題文一覧表示機能追加

## なぜこの変更をするのか

* 基本機能につき割愛

## やったこと

* [x] api/questions_controllerのindexアクションにquestionを全て返すインスタンス変数を設定。
* questions/index.vueで取得したquestionsをv-forで一覧表示するテンプレートを実装。
* コースごとに出題文の表示を切り替える実装は未完