### PR TITLE
出題文一覧表示機能rspec

### DIFF
--- a/app/controllers/api/questions_controller.rb
+++ b/app/controllers/api/questions_controller.rb
@@ -32,6 +32,7 @@ class Api::QuestionsController < ApplicationController
 
   def destroy
     Question.find(params[:id]).destroy
+    response_success(:question, :destroy)
   end
 
   private

--- a/spec/requests/api/questions_request_spec.rb
+++ b/spec/requests/api/questions_request_spec.rb
@@ -2,4 +2,99 @@ require 'rails_helper'
 
 RSpec.describe "Api::Questions", type: :request do
 
+  context "ログイン済みの管理者ユーザーの場合" do
+       let(:user){create(:user, :admin)}
+
+        before do
+          log_in_as user
+        end
+
+        describe "GET /index" do
+          it "成功レスポンス200を返す" do
+            get '/api/questions'
+            expect(response).to have_http_status "200"
+          end
+        end
+
+      #   describe "GET /new" do
+      #     it "renders new" do
+      #       get new_question_path
+      #       expect(response.body).to include "Create Questions"
+      #     end
+      #   end
+
+      #   describe "POST /create" do
+      #     context "空欄なく入力した場合" do
+      #       it "redirects to root path" do
+      #         expect{
+      #         post questions_path, params: {form_question_collection:
+      #                                     {questions_attributes:
+      #                                     {0=> {content: "test question1", mode_num:1},
+      #                                       1 =>{content: "test question2", mode_num:1},
+      #                                       2 =>{content: "test question3", mode_num:1},
+      #                                       3 =>{content: "test question4", mode_num:1},
+      #                                       4 =>{content: "test question5", mode_num:1},
+      #                                       5 =>{content: "test question6", mode_num:1},
+      #                                       6 =>{content: "test question7", mode_num:1},
+      #                                       7 =>{content: "test question8", mode_num:1},
+      #                                       8 =>{content: "test question9", mode_num:1},
+      #                                       9 =>{content: "test question10", mode_num:1}}}}
+      #          }.to change(Question, :count).by (10)
+      #         expect(response).to redirect_to root_path
+      #       end
+      #     end
+
+      #     context "空欄があった場合" do
+      #       it "render new" do
+      #         post questions_path, params: {form_question_collection:
+      #           {questions_attributes:
+      #           {0=> {content: ""}}}}
+
+      #         expect(response.body).to include "Create Questions"
+      #       end
+      #     end
+
+      #   end
+
+        describe "DELETE /destroy" do
+          let!(:question){create(:question)}
+
+          it "成功レスポンス200を返す" do
+            expect{
+              delete api_question_path(question), params: {id: question.id}
+            }.to change(Question, :count).by(-1)
+            expect(response).to have_http_status "200"
+          end
+        end
+      end
+
+     context "ログイン済みの管理者ではないユーザーの場合" do
+       let(:user){create(:user)}
+
+       before do
+         log_in_as user
+       end
+
+       describe "GET/ index" do
+         it "redirects to root path" do
+           get '/api/questions'
+           expect(response).to redirect_to root_path
+         end
+       end
+       #そのほかのアクションについては省略
+      end
+
+      context "ログイン済みではないユーザーの場合" do
+
+        describe "GET/ index" do
+          it "redirects to root path" do
+            get '/api/questions'
+            expect(response).to redirect_to login_path
+          end
+        end
+        #そのほかのアクションについては省略
+     end
+
+
+
 end


### PR DESCRIPTION
## 変更の概要

*questions request rspecに出題文一覧表示機能をテストする項目を追加

## なぜこの変更をするのか

* adminのフィルターが機能していること、及びquestionの削除が正常に行えるかテストするため。

## やったこと

* [x] login中のadminユーザーがapi/questions_controller indexアクションを実行したときに成功レスポンス200を返すことをテストで確認
* 上記ユーザーがdestroyアクションを実行すると正常にquestionを削除して成功レスポンス200を返すことをテストで確認
* destroyアクション成功時にレスポンス200を返すようにapi/questions_controller destroyに項目追加
* ログイン中の非adminユーザーがquestions index実行するとルートページにリダイレクトされることをテストで確認
* 非ログイン状態でquestionsパスにアクセスするとログインページにリダイレクトされることをテストで確認。