### PR TITLE
出題文作成機能

### DIFF
--- a/app/controllers/api/questions_controller.rb
+++ b/app/controllers/api/questions_controller.rb
@@ -2,31 +2,25 @@ class Api::QuestionsController < ApplicationController
   before_action :admined_user
 
   def index
-
     @questions = Question.where(mode_num: params[:mode_num])
     render json: @questions
-    # @questions = Kaminari.paginate_array(@questions).page(params[:page]).per(5)
   end
 
   def show
     @questions = Question.where(mode_num: params[:mode_num])
     @question = @questions.find(@questions.pluck(:id).sample)
-    # render 'show', formats: 'json', handlers: 'jbuilder'
     render json: {content: @question.content}
   end
 
   def new
-    @form = Form::QuestionCollection.new
   end
 
   def create
-    @form = Form::QuestionCollection.new(question_collection_params)
-    if @form.save
-      flash[:success] = "問題を作成しました。"
-      redirect_to root_url
+    @question = Question.new(question_params)
+    if @question.save
+      response_success(:question, :create)
     else
-      flash.now[:danger] = "問題の作成に失敗しました。"
-      render 'new'
+      response_bad_request
     end
   end
 
@@ -37,8 +31,8 @@ class Api::QuestionsController < ApplicationController
 
   private
 
-  def question_collection_params
-    params.require(:form_question_collection).permit(questions_attributes: [:content, :mode_num])
+  def question_params
+    params.require(:question).permit(:content, :mode_num)
   end
 
   #before action

--- a/app/javascript/src/questions/Index.vue
+++ b/app/javascript/src/questions/Index.vue
@@ -58,11 +58,7 @@
       deleteQuestion: function(id) {
         axios.delete('/api/questions/' + id)
         .then(response => {
-          this.$flashMessage.show({
-            type: 'success',
-            text:'問題を削除しました',
-            time: 5000
-          })
+         location.reload()
         .catch(err => {
             this.$flashMessage.show({
               type: 'error',

--- a/app/javascript/src/questions/New.vue
+++ b/app/javascript/src/questions/New.vue
@@ -1,6 +1,17 @@
 <template>
-  <div class="text-center items-center justify-center">
-    <p>New question</p>
+  <div class="text-white content-center">
+    <h1 class="text-center font-bold text-2xl mb-8">出題文作成</h1>
+    <div class="flex flex-col text-black mx-auto max-w-md">
+      <span class="text-white">出題モード選択</span>
+      <select v-model="question.mode_num" class="w-16 mb-8">
+        <option value=1>1</option>
+        <option value=2>2</option>
+      </select>
+      <input type="text" v-model="question.content" class="text-2xl w-full max-w-md h-full container mx-auto bg-white shadow-md rounded-lg pl-4 pt-6 pb-8 mb-4">
+      <button @click="questionNew" class="w-36 mx-auto mt-4 bg-white hover:bg-blue-500 text-blue-700 font-semibold hover:text-white py-2 px-4 border border-blue-500 hover:border-transparent rounded-full">作成する</button>
+    </div>
+
+
 
   </div>
 
@@ -10,7 +21,39 @@
   import axios from 'axios';
 
   export default {
-    name: 'QuestionNew'
+    name: 'QuestionNew',
+    data() {
+      return {
+        question: {
+          content: "",
+          mode_num: ""
+        }
+      }
+    },
+    methods: {
+      questionNew: function () {
+        axios.post('/api/questions', {
+          question: this.question
+        })
+        .then(response => {
+          this.$flashMessage.show({
+            type: 'success',
+            text:'問題を作成しました',
+            time: 5000
+          });
+          this.question.content=""
+        })
+        .catch(err => {
+            this.$flashMessage.show({
+              type: 'error',
+              text: '作成に失敗しました',
+              time: 5000
+            });
+        })
+
+      }
+    }
+
   }
 
 


### PR DESCRIPTION
## 変更の概要

* 管理者用ページの一つである出題文作成機能を追加

## なぜこの変更をするのか

* 基本機能につき割愛

## やったこと

* [x] api/questions_controller newアクション及びcreateアクション追加
* createでは単純にquestionのcontentとmode_numを保存する実装
* questions/new.vue にselectタグでmode_numを入力、inputタグで出題文を記述して保存できるテンプレートを実装。
* questions/index.vueの削除ボタンを押したときにリロードしないと画面から削除項目が消えなかったので削除成功後はリロードを行うようコード追加。