### PR TITLE
activation後の動作変更

### DIFF
--- a/app/assets/stylesheets/custom.scss
+++ b/app/assets/stylesheets/custom.scss
@@ -91,6 +91,6 @@
 
 // }
 
-.contribution {
-  float: left;
-}
+// .contribution {
+//   float: left;
+// }

--- a/app/controllers/api/account_activations_controller.rb
+++ b/app/controllers/api/account_activations_controller.rb
@@ -3,7 +3,7 @@ class Api::AccountActivationsController < ApplicationController
     user = User.find_by(email: params[:email])
     if user && !user.activated? && user.authenticated?(:activation, params[:id])
       user.activate
-      redirect_to root_path
+      redirect_to login_path
     else
       redirect_to root_path
 

--- a/app/javascript/src/components/Header.vue
+++ b/app/javascript/src/components/Header.vue
@@ -3,8 +3,9 @@
     <router-link to="/" class="font-serif text-3xl ">SelfTalkEnglish</router-link>
     <div class="float-right flex flex-row text-white font-bold mt-4 mr-10">
       <div v-if="$store.state.loggedIn && $store.state.notGuest">
-        <router-link :to="{name: 'show', params: {id: $store.state.userId}}">
-          <img src="/assets/user.svg" class="h-8 mr-16 border border-solid border-white rounded-full bg-gray-300 hover:bg-white"></router-link>
+        <router-link :to="{name: 'show', params: {id: $store.state.userId}}"
+        class="p-2 mr-16 border border-solid border-white rounded-full bg-yellow-500 hover:bg-yellow-300">
+          マイページ</router-link>
         <!-- ハンバーガーメニューのアイコン -->
         <div @click="showMenu" class="absolute z-10 block top-5 right-7 w-12 h-11 cursor-pointer transition duration-500">
         　<!-- 1番上の線 -->

--- a/app/javascript/src/users/Show.vue
+++ b/app/javascript/src/users/Show.vue
@@ -4,7 +4,7 @@
 
     <!-- 学習記録・contributions -->
     <div class="text-white p-4 max-w-md mx-auto border border-solid border-white rounded">
-      <div class="contribution">
+      <div class="float-left">
         <p class="ml-4">学習日数</p>
         <section class="w-24 h-24 pt-8 mb-4 text-center object-cover border border-solid border-white rounded-full">
         {{learningDays}}日</section>

--- a/spec/requests/api/account_activation_request_spec.rb
+++ b/spec/requests/api/account_activation_request_spec.rb
@@ -28,7 +28,7 @@ RSpec.describe "Api::AccountActivations", type: :request do
 
 
     it "ログインに成功する" do
-      expect(response).to redirect_to root_path
+      expect(response).to redirect_to login_path
       post '/api/login', params: { session: { email: user.email,
         password: 'password' } }
         expect(response).to have_http_status "200"


### PR DESCRIPTION
## 変更の概要

* account activation後の動作変更
* マイページリンクの表示変更

## なぜこの変更をするのか

* アカウント有効化リンクをクリック後、手動でログインする必要があるのでホーム画面に飛ぶのではなく、ログイン画面に遷移する方が親切だから
* マイページへのリンクを人型のアイコンにしていたがボタンにした方が見やすいから

## やったこと

* [x] api/account_activation edit アクション後、login_pathにリダイレクトするよう変更
* マイページリンクをボタンにデザイン変更