### PR TITLE
postcss.config.js変更

### DIFF
--- a/postcss.config.js
+++ b/postcss.config.js
@@ -2,6 +2,15 @@ module.exports = {
   plugins: [
     require('postcss-import'),
     require('postcss-flexbugs-fixes'),
+    require('@fullhuman/postcss-purgecss')({
+      content: [
+        './app/**/*.html.erb',
+        './app/**/*.js.erb',
+        './app/helpers/**/*.rb',
+      ],
+      safelist: ['a', 'open'],
+      defaultExtractor: content => content.match(/[A-Za-z0-9-_:/]+/g) || []
+    }),
     require('postcss-preset-env')({
       autoprefixer: {
         flexbox: 'no-2009'


### PR DESCRIPTION
## 変更の概要

* postcss.config.jsにpostcss-purgeをrequireする記述追加

## なぜこの変更をするのか

*本番環境でcssが崩れるバグ修正

## やったこと

* [x] postcsss.config.jsにrequire('@fullhuman/postcss-purgecss')({
      content: [
        './app/**/*.html.erb',
        './app/**/*.js.erb',
        './app/helpers/**/*.rb',
      ],
      # ここが重要
      safelist: ['a', 'open'],
      defaultExtractor: content => content.match(/[A-Za-z0-9-_:/]+/g) || []
    })を追加