### PR TITLE
item model と dictionary controller

### DIFF
--- a/app/controllers/api/dictionaries_controller.rb
+++ b/app/controllers/api/dictionaries_controller.rb
@@ -1,0 +1,2 @@
+class Api::DictionariesController < ApplicationController
+end

--- a/app/controllers/dictionaries_controller.rb
+++ b/app/controllers/dictionaries_controller.rb
@@ -1,0 +1,2 @@
+class DictionariesController < ApplicationController
+end

--- a/app/helpers/api/dictionaries_helper.rb
+++ b/app/helpers/api/dictionaries_helper.rb
@@ -1,0 +1,2 @@
+module Api::DictionariesHelper
+end

--- a/app/helpers/dictionaries_helper.rb
+++ b/app/helpers/dictionaries_helper.rb
@@ -1,0 +1,2 @@
+module DictionariesHelper
+end

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -1,0 +1,4 @@
+class Item < ApplicationRecord
+  validates :content, presence: true, length: {maximum: 100},
+  belongs_to :user
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -10,7 +10,9 @@ class User < ApplicationRecord
   has_secure_password
   validates :password, presence: true, length: { minimum: 6 }, allow_nil:true
   has_many :answers, dependent: :destroy
-  
+  has_many :items, dependent: :destroy
+
+
 
   # 渡された文字列のハッシュ値を返す
   def User.digest(string)

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -17,6 +17,7 @@ Rails.application.routes.draw do
   resources :password_resets, only: [:new, :create, :edit, :update]
   resources :questions
   resources :answers
+  resources :dictionaries
 
 
   # API controller
@@ -28,7 +29,7 @@ Rails.application.routes.draw do
     get '/guest_sign_in', to: 'guest_logins#guest_sign_in'
     post '/guest_sign_in', to: 'guest_logins#guest_sign_in'
   end
-  
+
   namespace :api, format: 'json' do
     resources :contacts
   end
@@ -52,6 +53,10 @@ Rails.application.routes.draw do
 
   namespace :api, format: 'json' do
     resources :questions
+  end
+  
+  namespace :api, format: 'json' do
+    resources :dictionaries
   end
 
 end

--- a/db/migrate/20211116133534_create_items.rb
+++ b/db/migrate/20211116133534_create_items.rb
@@ -1,0 +1,10 @@
+class CreateItems < ActiveRecord::Migration[6.0]
+  def change
+    create_table :items do |t|
+      t.string :content
+      t.references :user, null: false, foreign_key: true
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_11_04_113232) do
+ActiveRecord::Schema.define(version: 2021_11_16_133534) do
 
   create_table "answers", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3", force: :cascade do |t|
     t.text "content"
@@ -28,6 +28,14 @@ ActiveRecord::Schema.define(version: 2021_11_04_113232) do
     t.string "message"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+  end
+
+  create_table "items", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3", force: :cascade do |t|
+    t.string "content"
+    t.bigint "user_id", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["user_id"], name: "index_items_on_user_id"
   end
 
   create_table "questions", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3", force: :cascade do |t|
@@ -55,4 +63,5 @@ ActiveRecord::Schema.define(version: 2021_11_04_113232) do
 
   add_foreign_key "answers", "questions"
   add_foreign_key "answers", "users"
+  add_foreign_key "items", "users"
 end

--- a/spec/factories/items.rb
+++ b/spec/factories/items.rb
@@ -1,0 +1,6 @@
+FactoryBot.define do
+  factory :item do
+    content { "MyString" }
+    user { nil }
+  end
+end

--- a/spec/helpers/api/dictionaries_helper_spec.rb
+++ b/spec/helpers/api/dictionaries_helper_spec.rb
@@ -1,0 +1,15 @@
+require 'rails_helper'
+
+# Specs in this file have access to a helper object that includes
+# the Api::DictionariesHelper. For example:
+#
+# describe Api::DictionariesHelper do
+#   describe "string concat" do
+#     it "concats two strings with spaces" do
+#       expect(helper.concat_strings("this","that")).to eq("this that")
+#     end
+#   end
+# end
+RSpec.describe Api::DictionariesHelper, type: :helper do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/helpers/dictionaries_helper_spec.rb
+++ b/spec/helpers/dictionaries_helper_spec.rb
@@ -1,0 +1,15 @@
+require 'rails_helper'
+
+# Specs in this file have access to a helper object that includes
+# the DictionariesHelper. For example:
+#
+# describe DictionariesHelper do
+#   describe "string concat" do
+#     it "concats two strings with spaces" do
+#       expect(helper.concat_strings("this","that")).to eq("this that")
+#     end
+#   end
+# end
+RSpec.describe DictionariesHelper, type: :helper do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/models/item_spec.rb
+++ b/spec/models/item_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe Item, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/requests/api/dictionaries_request_spec.rb
+++ b/spec/requests/api/dictionaries_request_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe "Api::Dictionaries", type: :request do
+
+end

--- a/spec/requests/dictionaries_request_spec.rb
+++ b/spec/requests/dictionaries_request_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe "Dictionaries", type: :request do
+
+end


### PR DESCRIPTION
## 変更の概要

* item model および dictionary controllerの作成

## なぜこの変更をするのか

* 「マイ辞書」機能実装の下準備

## やったこと

* [x] rails g model item content:string user:references実行
* rails g controller dictionaries 実行
* rails g controller api/dictionaries 実行