### PR TITLE
item controllerでdictionary controller置き換え

### DIFF
--- a/app/controllers/api/dictionaries_controller.rb
+++ b/app/controllers/api/dictionaries_controller.rb
@@ -1,2 +1,0 @@
-class Api::DictionariesController < ApplicationController
-end

--- a/app/controllers/api/items_controller.rb
+++ b/app/controllers/api/items_controller.rb
@@ -1,0 +1,10 @@
+class Api::ItemsController < ApplicationController
+  def index
+  end
+
+  def new
+  end
+
+  def create
+  end
+end

--- a/app/controllers/dictionaries_controller.rb
+++ b/app/controllers/dictionaries_controller.rb
@@ -1,2 +1,0 @@
-class DictionariesController < ApplicationController
-end

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,0 +1,10 @@
+class ItemsController < ApplicationController
+  def index
+  end
+
+  def new
+  end
+
+  def create
+  end
+end

--- a/app/helpers/api/dictionaries_helper.rb
+++ b/app/helpers/api/dictionaries_helper.rb
@@ -1,2 +1,0 @@
-module Api::DictionariesHelper
-end

--- a/app/helpers/api/items_helper.rb
+++ b/app/helpers/api/items_helper.rb
@@ -1,0 +1,2 @@
+module Api::ItemsHelper
+end

--- a/app/helpers/dictionaries_helper.rb
+++ b/app/helpers/dictionaries_helper.rb
@@ -1,2 +1,0 @@
-module DictionariesHelper
-end

--- a/app/helpers/items_helper.rb
+++ b/app/helpers/items_helper.rb
@@ -1,0 +1,2 @@
+module ItemsHelper
+end

--- a/app/javascript/src/dictionaries/Index.vue
+++ b/app/javascript/src/dictionaries/Index.vue
@@ -1,0 +1,19 @@
+<template>
+  <div class="items-center justify-center">
+    <h1>マイ辞書</h1>
+  </div>
+
+</template>
+
+<script>
+  import axios from 'axios';
+
+  export default {
+    name: 'Items',
+    data() {
+      return {
+        answers: "",
+      }
+    }
+  }
+</script>

--- a/app/javascript/src/dictionaries/New.vue
+++ b/app/javascript/src/dictionaries/New.vue
@@ -1,0 +1,19 @@
+<template>
+  <div class="items-center justify-center">
+    <h1>マイ辞書</h1>
+  </div>
+
+</template>
+
+<script>
+  import axios from 'axios';
+
+  export default {
+    name: 'AddItems',
+    data() {
+      return {
+        answers: "",
+      }
+    },
+  }
+</script>

--- a/app/javascript/src/router.js
+++ b/app/javascript/src/router.js
@@ -14,6 +14,9 @@ import Answers from './answers/Index.vue'
 import AnswerEdit from './answers/Edit.vue'
 import Questions from './questions/Index.vue'
 import QuestionNew from './questions/New.vue'
+import Items from './dictionaries/Index.vue'
+
+
 
 
 
@@ -100,6 +103,11 @@ export const router = createRouter({
       path: '/questions',
       name: 'questions',
       component: Questions
+    },
+    {
+      path: '/items',
+      name: 'items',
+      component: Items
     }
   ],
 })

--- a/app/javascript/src/users/Show.vue
+++ b/app/javascript/src/users/Show.vue
@@ -39,7 +39,8 @@
         コース一覧へ</router-link>
       </button>
       <button class="underline bg-green-500 hover:bg-green-300 text-white font-semibold hover:text-white p-4 border border-solid border-white">
-        My辞書へ
+        <router-link to="/items" >
+        My辞書へ</router-link>
       </button>
     </div>
   </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -17,7 +17,7 @@ Rails.application.routes.draw do
   resources :password_resets, only: [:new, :create, :edit, :update]
   resources :questions
   resources :answers
-  resources :dictionaries
+  resources :items
 
 
   # API controller
@@ -54,9 +54,9 @@ Rails.application.routes.draw do
   namespace :api, format: 'json' do
     resources :questions
   end
-  
+
   namespace :api, format: 'json' do
-    resources :dictionaries
+    resources :items
   end
 
 end

--- a/spec/helpers/api/items_helper_spec.rb
+++ b/spec/helpers/api/items_helper_spec.rb
@@ -1,15 +1,15 @@
 require 'rails_helper'
 
 # Specs in this file have access to a helper object that includes
-# the DictionariesHelper. For example:
+# the Api::ItemsHelper. For example:
 #
-# describe DictionariesHelper do
+# describe Api::ItemsHelper do
 #   describe "string concat" do
 #     it "concats two strings with spaces" do
 #       expect(helper.concat_strings("this","that")).to eq("this that")
 #     end
 #   end
 # end
-RSpec.describe DictionariesHelper, type: :helper do
+RSpec.describe Api::ItemsHelper, type: :helper do
   pending "add some examples to (or delete) #{__FILE__}"
 end

--- a/spec/helpers/items_helper_spec.rb
+++ b/spec/helpers/items_helper_spec.rb
@@ -1,15 +1,15 @@
 require 'rails_helper'
 
 # Specs in this file have access to a helper object that includes
-# the Api::DictionariesHelper. For example:
+# the ItemsHelper. For example:
 #
-# describe Api::DictionariesHelper do
+# describe ItemsHelper do
 #   describe "string concat" do
 #     it "concats two strings with spaces" do
 #       expect(helper.concat_strings("this","that")).to eq("this that")
 #     end
 #   end
 # end
-RSpec.describe Api::DictionariesHelper, type: :helper do
+RSpec.describe ItemsHelper, type: :helper do
   pending "add some examples to (or delete) #{__FILE__}"
 end

--- a/spec/requests/api/dictionaries_request_spec.rb
+++ b/spec/requests/api/dictionaries_request_spec.rb
@@ -1,5 +1,0 @@
-require 'rails_helper'
-
-RSpec.describe "Api::Dictionaries", type: :request do
-
-end

--- a/spec/requests/api/items_request_spec.rb
+++ b/spec/requests/api/items_request_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe "Api::Items", type: :request do
+
+end

--- a/spec/requests/dictionaries_request_spec.rb
+++ b/spec/requests/dictionaries_request_spec.rb
@@ -1,5 +1,0 @@
-require 'rails_helper'
-
-RSpec.describe "Dictionaries", type: :request do
-
-end

--- a/spec/requests/items_request_spec.rb
+++ b/spec/requests/items_request_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe "Items", type: :request do
+
+end


### PR DESCRIPTION
## 変更の概要

* dictionary controllerでitem controllerで置き換え

## なぜこの変更をするのか

* item modelを扱うためコントローラー名作成の必要あり

## やったこと

* [x] dictionary contoller削除
* item controller作成
* item controller のvue-route設定