### PR TITLE
feat & fix: add question content to answer index

### DIFF
--- a/app/assets/stylesheets/custom.scss
+++ b/app/assets/stylesheets/custom.scss
@@ -271,24 +271,38 @@
 
 .answers{
   overflow-wrap: break-word;
-  margin-top: 32px;
-  margin-bottom: 32px;
+  margin-top: 128px;
+  margin-bottom: 128px;
   height: 92px;
-  background-color: white;
   list-style: none;
   font-size: 1.5rem;
   line-height: 2rem;
+}
+
+.course-btn{
+  text-align: center;
+  margin-top: 256px;
+}
+
+.answer-text-content {
+  background-color: white;
+  color: black;
+  width: 100%;
+  resize: none;
+  padding: 8px;
   border-width: 1px;
   border-style: solid;
   border-color: black;
   border-radius: 0.5rem;
 }
 
+.question-content {
+  color: white;
+
+}
+
 .edit-btn{
-  @media screen and (min-width: 768px) {
-    width: 13%;
-  }
- width: 30%;
+ width: 120px;
  background-color: rgba(59, 130, 246, var(--tw-bg-opacity));
  border-radius: 9999px;
  color: white;
@@ -300,11 +314,6 @@
 
 .edit-btn:hover{
   background-color: rgba(147, 197, 253, var(--tw-bg-opacity));
-}
-
-.course-btn{
-  text-align: center;
-  margin-top: 256px;
 }
 
 
@@ -384,6 +393,15 @@
   margin-bottom: 24px;
 }
 
+.contribution-progress {
+  width: 128px;
+  border-width: 1px;
+  border-style: solid;
+  border-color: white;
+  height: 16px;
+  margin-top: 4px;
+}
+
 
 //form
 
@@ -402,4 +420,5 @@
  }
 }
 
+//answer-edit
 

--- a/app/controllers/api/answers_controller.rb
+++ b/app/controllers/api/answers_controller.rb
@@ -4,9 +4,8 @@ class Api::AnswersController < ApplicationController
 
   def index
     @answers = current_user.answers.where(["created_at Like ?", "%#{params[:created_at]}%"])
-    # @answers = Kaminari.paginate_array(@answers).page(params[:page]).per(5)
-    render json: @answers
-
+    @answers_q_ids = @answers.map{|answer| answer.question.id}
+    @questions = Question.where(id: @answers_q_ids)
   end
 
   def new

--- a/app/javascript/src/App.vue
+++ b/app/javascript/src/App.vue
@@ -1,7 +1,7 @@
 <template>
   <main>
     <Header nav1="ログイン" nav2="新規登録"/>
-    <div class="contents">
+    <div class="flex-grow p-24">
       <FlashMessage position="left top"/>
       <router-view />
     </div>

--- a/app/javascript/src/answers/Index.vue
+++ b/app/javascript/src/answers/Index.vue
@@ -3,9 +3,12 @@
     <h1 class="font-bold text-2xl text-center text-white">回答集</h1>
     <MyMenu />
     <div v-for="answer in answers" class="answers" :key="answer">
-      <textarea v-model="answer.content" disabled class="w-full resize-none"></textarea>
+      <li v-for="question in questions" :key="question" class="question-content">
+        Q, {{question.content}}
+        <textarea v-model="answer.content" disabled class="answer-text-content"></textarea>
+      </li>
       <li class="edit-btn">
-       <router-link :to="{name: 'answerEdit', params: {id: answer.id}}" >
+       <router-link :to="{name: 'answerEdit', params: {id: answer.id}}">
         添削する
       </router-link></li>
     </div>
@@ -25,6 +28,7 @@
     data() {
       return {
         answers: "",
+        questions: ""
       }
     },
     mounted() {
@@ -38,7 +42,9 @@
           }
         })
         .then(response => {
-          this.answers = response.data
+          this.answers = response.data.answers
+          this.questions = response.data.questions
+          console.log(response.data)
         })
       }
     }

--- a/app/javascript/src/users/Show.vue
+++ b/app/javascript/src/users/Show.vue
@@ -16,7 +16,7 @@
         <section v-for="day in days" :key="day" class="flex flex-row">
           <span>{{day}}</span>
           <progress :value="contributions.filter(n => n.includes(day)).length" max="30"
-          class="w-32 mt-1 border border-solid border-white h-4"></progress>
+          class="contribution-progress"></progress>
           <span>{{contributions.filter(n => n.includes(day)).length}}
           </span>
         </section>

--- a/app/views/api/answers/index.json.jbuilder
+++ b/app/views/api/answers/index.json.jbuilder
@@ -1,1 +1,7 @@
+json.questions do
+  json.array! @questions
+end
 
+json.answers do
+  json.array! @answers
+end


### PR DESCRIPTION
## 変更の概要

* answer-indexのcss修正
* answer-indexのanswerの上に質問文を表示する

## なぜこの変更をするのか

* answer一覧で一緒に出題文を表示するため

## やったこと

* [x] api/answers_controllerのindexアクションでanswer一覧に紐づいたquestionを取得する変数を設定
* answers/index componentに取得したquestionの質問文をv-forで一緒に表示するよう実装
* answers/index componentのtailwind cssを一部custom.scssに移行