### PR TITLE
fix: heroku err about controller removal

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,7 +1,7 @@
-# class UsersController < ApplicationController
+class UsersController < ApplicationController
 
 
 
 
 
-# end
+end


### PR DESCRIPTION
## 変更の概要

* users_controllerのコメント修正

## なぜこの変更をするのか

* heroku上でusers_controllerに関するエラーが発生したため修正

## やったこと

* [x] users_controllerのコメント化した部分を戻した