### PR TITLE
refactor: items

### DIFF
--- a/app/controllers/api/contacts_controller.rb
+++ b/app/controllers/api/contacts_controller.rb
@@ -1,10 +1,9 @@
 class Api::ContactsController < ApplicationController
 
-  #問い合わせ機能
-  
   def new
   end
 
+  #問い合わせ機能
   def create
     @inquiry = Inquiry.new(inquiry_params)
     if @inquiry.save

--- a/app/controllers/api/items_controller.rb
+++ b/app/controllers/api/items_controller.rb
@@ -3,11 +3,12 @@ class Api::ItemsController < ApplicationController
   before_action :logged_in_user
   before_action :not_guest_user, only: [:index, :create, :destroy]
 
+  #items一覧表示機能
   def index
     @items = @user.items.all
-    render json: @items
   end
 
+  #items作成機能
   def create
     @item = @user.items.new(item_params)
     if @item.save
@@ -17,6 +18,7 @@ class Api::ItemsController < ApplicationController
     end
   end
 
+  #items削除機能
   def destroy
     @item = @user.items.find(params[:id])
     @item.destroy

--- a/app/controllers/api/questions_controller.rb
+++ b/app/controllers/api/questions_controller.rb
@@ -6,7 +6,6 @@ class Api::QuestionsController < ApplicationController
     @questions1 = Question.where(mode_num: 1) #explain course
     @questions2 = Question.where(mode_num: 2) #reaction course
     @questions3 = Question.where(mode_num: 3) #translate course
-
   end
 
   #ランダムな出題を行う機能

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,10 +1,10 @@
 class ItemsController < ApplicationController
-  def index
-  end
+  # def index
+  # end
 
-  def new
-  end
+  # def new
+  # end
 
-  def create
-  end
+  # def create
+  # end
 end

--- a/app/javascript/src/components/MyMenu.vue
+++ b/app/javascript/src/components/MyMenu.vue
@@ -10,7 +10,7 @@
         </router-link>
       </li>
       <li>
-        <router-link to="/items" class="dictionary-link">
+        <router-link to="/dictionaries" class="dictionary-link">
           単語帳
         </router-link>
       </li>

--- a/app/javascript/src/dictionaries/Dictionary.vue
+++ b/app/javascript/src/dictionaries/Dictionary.vue
@@ -6,10 +6,12 @@
 
     <MyMenu />
 
+    <!-- 新規追加欄 -->
     <div>
       <AddItems />
     </div>
 
+    <!-- 保存した単語・フレーズ一覧表示 -->
     <div v-for="item in items" :key="item" class="items">
       <textarea v-model="item.content" disabled class="items-colum"></textarea>
 
@@ -22,11 +24,7 @@
       </button>
 
       <input type="checkbox" class="checkbox">
-
-
-
     </div>
-
   </div>
 
 </template>
@@ -37,7 +35,7 @@
   import axios from 'axios';
 
   export default {
-    name: 'Items',
+    name: 'Dictionary',
     components: {
       AddItems,
       MyMenu
@@ -55,8 +53,7 @@
       getItems: function() {
         axios.get('/api/items')
         .then(response => {
-          this.items = response.data
-          console.log(response.data)
+          this.items = response.data.items
         })
       },
       //保存したフレーズを削除するメソッド

--- a/app/javascript/src/dictionaries/New.vue
+++ b/app/javascript/src/dictionaries/New.vue
@@ -15,7 +15,7 @@
         </textarea>
       </div>
       <div>
-        <label for="item_memo" class="text-white">例文</label>
+        <label for="item_memo" class="text-white">例文・メモ</label>
         <textarea
           v-model="item.memo"
           class="border border-solid border-black pl-3 pt-3 h-20 w-64 resize-none">

--- a/app/javascript/src/router.js
+++ b/app/javascript/src/router.js
@@ -14,7 +14,7 @@ import Answers from './answers/Index.vue'
 import AnswerEdit from './answers/Edit.vue'
 import Questions from './questions/Admin.vue'
 import QuestionNew from './questions/New.vue'
-import Items from './dictionaries/Index.vue'
+import Dictionary from './dictionaries/Dictionary.vue'
 
 
 
@@ -105,9 +105,9 @@ export const router = createRouter({
       component: Questions
     },
     {
-      path: '/items',
-      name: 'items',
-      component: Items
+      path: '/dictionaries',
+      name: 'dictionary',
+      component: Dictionary
     }
   ],
 })

--- a/app/views/api/answers/index.json.jbuilder
+++ b/app/views/api/answers/index.json.jbuilder
@@ -1,7 +1,3 @@
-# json.questions do
-#   json.array! @questions
-# end
-
 json.answers do
   json.array! @answers
 end

--- a/app/views/api/items/index.json.jbuilder
+++ b/app/views/api/items/index.json.jbuilder
@@ -1,0 +1,3 @@
+json.items do
+  json.array! @items
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,6 +5,7 @@ Rails.application.routes.draw do
   get '/users/:id', to: 'api/users#show'
   get '/users/:id/edit', to: 'api/users#edit'
   get '/admin_page', to: 'api/questions#index'
+  get '/dictionaries', to: 'api/items#index'
   #routing
   get '/about', to: 'static_pages#about'
   get '/policy', to: 'static_pages#policy'
@@ -18,7 +19,7 @@ Rails.application.routes.draw do
   resources :password_resets, only: [:new, :create, :edit, :update]
   # resources :questions
   resources :answers
-  resources :items
+  # resources :items
 
 
   # API controller

--- a/spec/models/item_spec.rb
+++ b/spec/models/item_spec.rb
@@ -3,30 +3,30 @@ require 'rails_helper'
 RSpec.describe Item, type: :model do
   let(:item){create(:item)}
 
-  it "is invalid with more than 50 leters in content" do
+  it "contentが51字以上の時、無効" do
     item.content = "a" * 51
     expect(item).to_not be_valid
   end
 
-  it "is invalid with more than 50 leters in meaning" do
+  it "maniengが51字以上の時、無効" do
     item.meaning = "a" * 51
     expect(item).to_not be_valid
   end
-  it "is invalid with more than 50 leters in memo" do
+  it "memoが101字以上の時、無効" do
     item.memo = "a" * 101
     expect(item).to_not be_valid
   end
 
-  it "is valid with less than 50 leters in content" do
+  it "contentが50字以下の時、有効" do
     item.content = "a" * 50
     expect(item).to be_valid
   end
-  it "is valid with less than 50 leters in meaning" do
+  it "maniengが50字以下の時、有効" do
     item.meaning = "a" * 50
     expect(item).to be_valid
   end
 
-  it "is valid with less than 100 leters in memo" do
+  it "memoが100字以下の時、有効" do
     item.memo = "a" * 100
     expect(item).to be_valid
   end

--- a/spec/requests/api/items_request_spec.rb
+++ b/spec/requests/api/items_request_spec.rb
@@ -2,60 +2,108 @@ require 'rails_helper'
 
 RSpec.describe "Api::Items", type: :request do
   let(:user){create(:user)}
+  let!(:item){create(:item, user_id: user.id)}
   context "ログイン済みユーザーの場合" do
-      before do
-        log_in_as user
+    before do
+      log_in_as user
+    end
+
+    describe "GET /index" do
+      let!(:item){create(:item)}
+      it "成功レスポンス200を返す" do
+        get api_items_path
+        expect(response).to have_http_status "200"
       end
+    end
 
-      describe "GET /index" do
-        let!(:item){create(:item)}
-        it "成功レスポンス200を返す" do
-          get '/api/items'
-          expect(response).to have_http_status "200"
-        end
-      end
-
-      describe "POST /create" do
-
-        context "itemが空欄ではない場合" do
-          it "itemを保存しレスポンス200を返す" do
-            expect{
-            post api_items_path, params: {id: user.id, item: {content: "test", meaning: "test", memo:"test"}}
-            }.to change(Item, :count).by(1)
-            expect(response).to have_http_status "200"
-          end
-        end
-        context "item追加欄に空欄がある場合" do
-          it "answerが保存されずレスポンス400を返す" do
-            expect{
-            post api_items_path, params: {id: user.id, item: {content: "", meaning:"test", memo:"test"}}
-            }.to change(Item, :count).by(0)
-            expect(response).to have_http_status "400"
-          end
-        end
-      end
-
-      describe "Delete /destroy" do
-        let!(:item){create(:item, user_id: user.id)}
-
-        it "成功レスポンス200を返す" do
+    describe "POST /create" do
+      context "itemが空欄ではない場合" do
+        it "itemを保存しレスポンス200を返す" do
           expect{
-            delete api_item_path(item), params: {id: item.id}
-          }.to change(Item, :count).by(-1)
+          post api_items_path, params:
+          {id: user.id, item: {content: "test", meaning: "test", memo:"test"}}
+          }.to change(Item, :count).by(1)
           expect(response).to have_http_status "200"
+        end
+      end
+      context "item追加欄に空欄がある場合" do
+        it "answerが保存されずレスポンス400を返す" do
+          expect{
+          post api_items_path, params:
+          {id: user.id, item: {content: "", meaning:"test", memo:"test"}}
+          }.to change(Item, :count).by(0)
+          expect(response).to have_http_status "400"
         end
       end
     end
 
-  context "ログイン済みでないユーザーの場合" do
+    describe "Delete /destroy" do
+      it "成功レスポンス200を返す" do
+        expect{
+        delete api_item_path(item), params: {id: item.id}
+        }.to change(Item, :count).by(-1)
+        expect(response).to have_http_status "200"
+      end
+    end
+  end
 
+  context "ログイン済みでないユーザーの場合" do
     describe "GET /index" do
       it "redirects to login path" do
-        get '/api/items'
+        get api_items_path
         expect(response).to redirect_to login_path
       end
     end
-    #そのほかのアクションについては省略
+
+    describe "POST /create" do
+      it "itemは生成されず、login_pathにリダイレクトする" do
+        expect{
+          post api_items_path, params:
+          {id: user.id, item: {content: "test", meaning: "test", memo:"test"}}
+          }.to change(Item, :count).by(0)
+          expect(response).to redirect_to login_path
+      end
+    end
+
+    describe "Delete /destroy" do
+      it "itemは削除されず、login_pathにリダイレクトする" do
+        expect{
+          delete api_item_path(item), params: {id: item.id}
+        }.to change(Item, :count).by(0)
+        expect(response).to redirect_to login_path
+      end
+    end
   end
 
+  context "ゲストログイン中の場合" do
+    before do
+      guest_login
+    end
+
+    describe "GET /index" do
+      it "redirects to root_path" do
+        get api_items_path
+        expect(response).to redirect_to root_path
+      end
+    end
+
+    describe "POST /create" do
+      it "itemは生成されず、root_pathにリダイレクトする" do
+        expect{
+          post api_items_path, params:
+          {id: user.id, item: {content: "test", meaning: "test", memo:"test"}}
+          }.to change(Item, :count).by(0)
+          expect(response).to redirect_to root_path
+      end
+    end
+
+    describe "Delete /destroy" do
+      it "itemは削除されず、root_pathにリダイレクトする" do
+        expect{
+          delete api_item_path(item), params: {id: item.id}
+        }.to change(Item, :count).by(0)
+        expect(response).to redirect_to root_path
+      end
+    end
+  end
 end


### PR DESCRIPTION
## 変更の概要

*api/items_controller, items関連component, rspecリファクタリング

## なぜこの変更をするのか

*可読性向上
*不要部分削除
*バグ検知



## やったこと

* [x] api/items_controller rspecにコメント追加
* [x] 上記rspecにbeforeアクションをテストする項目追加
* [x] api/items_controller indexアクションのrender jsonをjbuilder ファイルに移行（url直うちのさいにjsonデータだけ表示されてコンポーネントが表示されないため）
* [x] dictionary/items componentの名称及びルート名を変更
* [x] 上記に準じてリンクを修正
* [x] items_controllerのアクションを削除
* [x] routes.rbで/dictionariesアクセス時にapi/items#indexを実行するよう設定