### PR TITLE
refactor: answers index routes

### DIFF
--- a/app/javascript/src/answers/Index.vue
+++ b/app/javascript/src/answers/Index.vue
@@ -38,7 +38,7 @@
     methods: {
       //特定日付のanswer一覧のデータを受け取るメソッド
       getAnswers: function() {
-        axios.get('api/answers', {
+        axios.get(`/users/${this.$route.params.id}/api/answers`, {
           params: {
             created_at: this.$route.query.created_at
           }

--- a/app/javascript/src/router.js
+++ b/app/javascript/src/router.js
@@ -85,7 +85,7 @@ export const router = createRouter({
       component: Courses
     },
     {
-      path: '/answers',
+      path: '/users/:id/answers',
       name: 'answers',
       component: Answers
     },

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -7,6 +7,7 @@ Rails.application.routes.draw do
   get '/admin_page', to: 'api/questions#index'
   get '/dictionaries', to: 'api/items#index'
   get '/course', to: 'api/answers#new'
+  get '/users/:id/answers', to: 'api/answers#index'
   #routing
   get '/about', to: 'static_pages#about'
   get '/policy', to: 'static_pages#policy'
@@ -26,6 +27,16 @@ Rails.application.routes.draw do
   # API controller
   namespace :api, format: 'json' do
     resources :users
+  end
+
+  resources :users do
+    namespace :api, format: 'json' do
+      resources :answers, only: [:index]
+    end
+  end
+
+  namespace :api, format: 'json' do
+    resources :answers, only: [:new, :create, :edit, :update]
   end
 
   namespace :api, format: 'json' do
@@ -50,9 +61,6 @@ Rails.application.routes.draw do
     resources :account_activations, only: [ :edit ]
   end
 
-  namespace :api, format: 'json' do
-    resources :answers
-  end
 
   namespace :api, format: 'json' do
     resources :questions

--- a/spec/requests/api/answers_request_spec.rb
+++ b/spec/requests/api/answers_request_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe "Answers", type: :request do
       describe "GET/ index" do
         let!(:answer){create(:answer)}
         it "成功レスポンス200を返す" do
-          get api_answers_path
+          get user_api_answers_path(user)
           expect(response).to have_http_status "200"
         end
       end
@@ -72,7 +72,7 @@ RSpec.describe "Answers", type: :request do
   context "ログイン済みでないユーザーの場合" do
     describe "GET/ index" do
       it "login_pathにリダイレクトする" do
-        get api_answers_path
+        get user_api_answers_path(user)
         expect(response).to redirect_to login_path
       end
     end
@@ -115,7 +115,7 @@ RSpec.describe "Answers", type: :request do
 
     describe "GET/ index" do
       it "root_pathにリダイレクトする" do
-        get api_answers_path
+        get user_api_answers_path(user)
         expect(response).to redirect_to root_path
       end
     end


### PR DESCRIPTION
## 変更の概要

* answers のルーティングリファクタリング

## なぜこの変更をするのか

* urlネストによる紐付けのため

## やったこと

* [x] router.jsの/answersを/users/:id/answersに変更
* [x] answers/Index.vueのmethods(getAnswers)の取得先パスを上記に合わせて変更
* [x]routes.rbにusers resoursesにapi/answers resoursesをネストするよう記述追加（indexのみ）
* answersの他アクションについては次回、ネスト設定