### PR TITLE
refactor: answers edit route

### DIFF
--- a/app/controllers/answers_controller.rb
+++ b/app/controllers/answers_controller.rb
@@ -1,14 +1,4 @@
 class AnswersController < ApplicationController
-  before_action :logged_in_user, only: [:index, :edit]
-  before_action :not_guest_user, only: [:index, :edit]
 
-  def index
-  end
-
-  def new
-  end
-
-  def edit
-  end
 end
 

--- a/app/javascript/src/answers/Edit.vue
+++ b/app/javascript/src/answers/Edit.vue
@@ -51,7 +51,8 @@
     methods: {
       //answerのデータを受け取るメソッド
       getAnswer: function () {
-        axios.get(`/api/answers/${this.$route.params.id}/edit`)
+        axios.get(`/users/${this.$store.state.userId}/api/answers/
+        ${this.$route.params.id}/edit`)
         .then(response => {
           this.question = response.data.question
           this.answer= response.data

--- a/app/javascript/src/answers/Index.vue
+++ b/app/javascript/src/answers/Index.vue
@@ -9,7 +9,8 @@
     <div v-for="answer in answers" class="answers" :key="answer">
       <textarea v-model="answer.content" disabled class="answer-text-content"></textarea>
       <li class="edit-btn">
-       <router-link :to="{name: 'answerEdit', params: {id: answer.id}}">
+       <router-link :to="{name: 'answerEdit', params: {user_id: $store.state.userId,
+       id: answer.id}}">
          添削する
        </router-link>
       </li>

--- a/app/javascript/src/router.js
+++ b/app/javascript/src/router.js
@@ -90,7 +90,7 @@ export const router = createRouter({
       component: Answers
     },
     {
-      path: '/answers/:id/edit',
+      path: '/users/:user_id/answers/:id/edit',
       name: 'answerEdit',
       component: AnswerEdit
     },

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -8,6 +8,7 @@ Rails.application.routes.draw do
   get '/dictionaries', to: 'api/items#index'
   get '/course', to: 'api/answers#new'
   get '/users/:id/answers', to: 'api/answers#index'
+  get '/users/:id/answers/:id/edit', to: 'api/answers#edit'
   #routing
   get '/about', to: 'static_pages#about'
   get '/policy', to: 'static_pages#policy'
@@ -20,7 +21,7 @@ Rails.application.routes.draw do
   resources :account_activations, only: [:edit]
   resources :password_resets, only: [:new, :create, :edit, :update]
   # resources :questions
-  resources :answers
+  # resources :answers
   # resources :items
 
 
@@ -31,12 +32,12 @@ Rails.application.routes.draw do
 
   resources :users do
     namespace :api, format: 'json' do
-      resources :answers, only: [:index]
+      resources :answers, only: [:index, :edit]
     end
   end
 
   namespace :api, format: 'json' do
-    resources :answers, only: [:new, :create, :edit, :update]
+    resources :answers, only: [:new, :create, :update]
   end
 
   namespace :api, format: 'json' do

--- a/spec/requests/api/answers_request_spec.rb
+++ b/spec/requests/api/answers_request_spec.rb
@@ -47,7 +47,7 @@ RSpec.describe "Answers", type: :request do
 
     describe "GET/ edit" do
       it "成功レスポンス200を返す" do
-        get edit_api_answer_path(answer)
+        get edit_user_api_answer_path(user, answer)
         expect(response).to have_http_status "200"
       end
     end
@@ -95,7 +95,7 @@ RSpec.describe "Answers", type: :request do
 
     describe "GET/ edit" do
       it "login_pathにリダイレクトする" do
-        get edit_api_answer_path(answer)
+        get edit_user_api_answer_path(user, answer)
         expect(response).to redirect_to login_path
       end
     end
@@ -122,7 +122,7 @@ RSpec.describe "Answers", type: :request do
 
     describe "GET/ edit" do
       it "root_pathにリダイレクトする" do
-        get edit_api_answer_path(answer)
+        get edit_user_api_answer_path(user, answer)
         expect(response).to redirect_to root_path
       end
     end


### PR DESCRIPTION
## 変更の概要

* answers/editのルーティングリファクタリング

## なぜこの変更をするのか

* url nestによりurlの明示性向上

## やったこと

* [x] router.jsの/answers/:id/editを/users/:user_id/answers/:id/editに変更
* [x] answers/Index.vueに仕込まれているEdit.vueのリンクにuser_idのparamsを組み込み
* [x] answers/Edit.vueのgetAnswerメソッドのaxios.getパスを変更
* [x] routes.rbに上記ネストされたURLにアクセスがあった際はapi/answers#editを実行するよう設定
* [x] routes.rbからanswers respursesを削除
* [x] answers_controllerのアクションを全て削除
* [x] api/answers_controller rspecのeditをテストする項目のパスをネストURLに合わせて変更