### PR TITLE
refactor: items routes

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,10 +1,2 @@
 class ItemsController < ApplicationController
-  # def index
-  # end
-
-  # def new
-  # end
-
-  # def create
-  # end
 end

--- a/app/javascript/src/components/MyMenu.vue
+++ b/app/javascript/src/components/MyMenu.vue
@@ -10,7 +10,7 @@
         </router-link>
       </li>
       <li>
-        <router-link to="/dictionaries" class="dictionary-link">
+        <router-link :to="{name: 'dictionary', params: {id: $store.state.userId}}" class="dictionary-link">
           単語帳
         </router-link>
       </li>

--- a/app/javascript/src/dictionaries/Dictionary.vue
+++ b/app/javascript/src/dictionaries/Dictionary.vue
@@ -51,7 +51,7 @@
     //保存したフレーズ集を取得するメソッド
     methods: {
       getItems: function() {
-        axios.get('/api/items')
+        axios.get(`/users/${this.$route.params.id}/api/items`)
         .then(response => {
           this.items = response.data.items
         })

--- a/app/javascript/src/router.js
+++ b/app/javascript/src/router.js
@@ -105,7 +105,7 @@ export const router = createRouter({
       component: Questions
     },
     {
-      path: '/dictionaries',
+      path: '/users/:id/dictionaries',
       name: 'dictionary',
       component: Dictionary
     }

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,10 +5,11 @@ Rails.application.routes.draw do
   get '/users/:id', to: 'api/users#show'
   get '/users/:id/edit', to: 'api/users#edit'
   get '/admin_page', to: 'api/questions#index'
-  get '/dictionaries', to: 'api/items#index'
+  get '/users/:id/dictionaries', to: 'api/items#index'
   get '/course', to: 'api/answers#new'
   get '/users/:id/answers', to: 'api/answers#index'
   get '/users/:id/answers/:id/edit', to: 'api/answers#edit'
+
   #routing
   get '/about', to: 'static_pages#about'
   get '/policy', to: 'static_pages#policy'
@@ -33,11 +34,16 @@ Rails.application.routes.draw do
   resources :users do
     namespace :api, format: 'json' do
       resources :answers, only: [:index, :edit]
+      resources :items, only: [:index]
     end
   end
 
   namespace :api, format: 'json' do
     resources :answers, only: [:new, :create, :update]
+  end
+
+  namespace :api do
+    resources :items, only: [:create, :destroy]
   end
 
   namespace :api, format: 'json' do
@@ -62,13 +68,10 @@ Rails.application.routes.draw do
     resources :account_activations, only: [ :edit ]
   end
 
-
   namespace :api, format: 'json' do
     resources :questions
   end
 
-  namespace :api, format: 'json' do
-    resources :items
-  end
+
 
 end

--- a/spec/requests/api/items_request_spec.rb
+++ b/spec/requests/api/items_request_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe "Api::Items", type: :request do
     describe "GET /index" do
       let!(:item){create(:item)}
       it "成功レスポンス200を返す" do
-        get api_items_path
+        get user_api_items_path(user)
         expect(response).to have_http_status "200"
       end
     end
@@ -50,7 +50,7 @@ RSpec.describe "Api::Items", type: :request do
   context "ログイン済みでないユーザーの場合" do
     describe "GET /index" do
       it "redirects to login path" do
-        get api_items_path
+        get user_api_items_path(user)
         expect(response).to redirect_to login_path
       end
     end
@@ -82,7 +82,7 @@ RSpec.describe "Api::Items", type: :request do
 
     describe "GET /index" do
       it "redirects to root_path" do
-        get api_items_path
+        get user_api_items_path(user)
         expect(response).to redirect_to root_path
       end
     end


### PR DESCRIPTION
## 変更の概要

* items 関連routeのリファクタリング

## なぜこの変更をするのか

* urlをネストすることによるurlの明示性向上

## やったこと

* [x] api/items_controllerのindexアクションだけusers resoursesにネスト
* [x] dictionaries/Dictionary.vueのパスをusers/:id/dictionariesに変更
* [x]MyMenu.vueの/dictionariesへのリンクを上記パスに変更
* [x]dictionaries/Dictionary.vueのaxios.getのパスを上記パスに変更
* [x]routes.rbに/users/:iddictionariesへアクセス時はapi/items#indexを実行するよう設定
* [x]api/items_controller rspecのindexテスト項目のパスを変更