### PR TITLE
refactor: password_resets routes

### DIFF
--- a/app/controllers/api/password_resets_controller.rb
+++ b/app/controllers/api/password_resets_controller.rb
@@ -2,8 +2,11 @@ class Api::PasswordResetsController < ApplicationController
   before_action :get_user,   only: [:update]
   before_action :valid_user, only: [:update]
   before_action :check_expiration, only: [:update]
-  before_action :not_logged_in, only: [:create, :update]
-  before_action :not_guest_user, only: [:create, :update]
+  before_action :not_logged_in, only: [:new, :create, :edit, :update]
+  before_action :not_guest_user, only: [:new, :create, :edit, :update]
+
+  def new
+  end
 
   def create
     @user = User.find_by(email: params[:password_reset][:email].downcase)
@@ -13,6 +16,9 @@ class Api::PasswordResetsController < ApplicationController
     else
       response_bad_request
     end
+  end
+
+  def edit
   end
 
   def update

--- a/app/controllers/password_resets_controller.rb
+++ b/app/controllers/password_resets_controller.rb
@@ -1,29 +1,2 @@
 class PasswordResetsController < ApplicationController
-  before_action :not_logged_in, only: [:new, :edit]
-  before_action :not_guest_user, only: [:new, :edit]
-  before_action :valid_user, only: [:edit]
-
-  def new
-  end
-
-  def create
-  end
-
-
-  def edit
-  end
-
-  def update
-  end
-
-  #before action
-
-   # 正しいユーザーかどうか確認する
-   def valid_user
-    @user = User.find_by(email: params[:email])
-    unless (@user && @user.activated? &&
-            @user.authenticated?(:reset, params[:id]))
-      redirect_to root_path
-    end
-  end
 end

--- a/app/views/user_mailer/password_reset.html.erb
+++ b/app/views/user_mailer/password_reset.html.erb
@@ -1,13 +1,12 @@
-<h1>Password reset</h1>
+<h1>パスワード再設定</h1>
 
-<p>To reset your password click the link below:</p>
+<p>下記リンクからパスワードの再設定を行ってください。</p>
 
 <%= link_to "Reset password", edit_password_reset_url(@user.reset_token,
                                                       email: @user.email) %>
 
-<p>This link will expire in two hours.</p>
+<p>このリンクは2時間後に使用できなくなります。</p>
 
 <p>
-If you did not request your password to be reset, please ignore this email and
-your password will stay as it is.
+もし当メールに心当たりがないようでしたらご放念ください。
 </p>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,9 +1,12 @@
 Rails.application.routes.draw do
-
+  
+　#vue-routerで設定したurlをapi/controllerに割り振り
   get '/contacts', to: 'api/contacts#new'
   get '/users/new', to: 'api/users#new'
   get '/users/:id', to: 'api/users#show'
   get '/users/:id/edit', to: 'api/users#edit'
+  get '/password_resets/new', to: 'api/password_resets#new'
+  get '/password_resets/:reset_token/edit', to: 'api/password_resets#edit'
   get '/admin_page', to: 'api/questions#index'
   get '/users/:id/dictionaries', to: 'api/items#index'
   get '/course', to: 'api/answers#new'
@@ -18,12 +21,10 @@ Rails.application.routes.draw do
   get    '/login',   to: 'sessions#new'
   post   '/login',   to: 'sessions#create'
   delete '/logout',  to: 'sessions#destroy'
-  # resources :users
+
   resources :account_activations, only: [:edit]
-  resources :password_resets, only: [:new, :create, :edit, :update]
-  # resources :questions
-  # resources :answers
-  # resources :items
+  resources :password_resets, only: [:edit]
+
 
 
   # API controller
@@ -31,7 +32,7 @@ Rails.application.routes.draw do
     resources :users
   end
 
-  resources :users do
+  resources :users do  #answers, itemsのネストURL生成
     namespace :api, format: 'json' do
       resources :answers, only: [:index, :edit]
       resources :items, only: [:index]
@@ -60,8 +61,8 @@ Rails.application.routes.draw do
     delete '/logout', to: 'sessions#destroy'
   end
 
-  namespace :api do
-    resources :password_resets, only: [:create, :update]
+  namespace :api, format: 'json' do
+    resources :password_resets, only: [:new, :create, :edit, :update]
   end
 
   namespace :api do

--- a/spec/requests/api/password_resets_request_spec.rb
+++ b/spec/requests/api/password_resets_request_spec.rb
@@ -4,12 +4,18 @@ RSpec.describe "Api::PasswordResets", type: :request do
   let(:user) { create(:user) }
   before { user.create_reset_digest }
 
+  describe "GET /new" do
+    it "成功レスポンス204返す" do
+      get new_api_password_reset_path
+      expect(response).to have_http_status "204"
+    end
+  end
+
   describe "POST /create" do
     context "誤ったメールアドレスが入力された場合" do
       it "エラー400を返す" do
         post api_password_resets_path, params: {password_reset: {email: ""}}
         expect(response).to have_http_status "400"
-
       end
     end
 
@@ -17,6 +23,15 @@ RSpec.describe "Api::PasswordResets", type: :request do
       it "レスポンス204を返す" do
         post api_password_resets_path, params: {password_reset: {email: user.email}}
         expect(ActionMailer::Base.deliveries.size).to eq(1)
+        expect(response).to have_http_status "204"
+      end
+    end
+  end
+
+  describe "GET /edit" do
+    context "メールアドレス・トークンが有効な場合" do
+      it "成功レスポンス204を返す" do
+        get edit_api_password_reset_path(user.reset_token, email: user.email)
         expect(response).to have_http_status "204"
       end
     end

--- a/spec/requests/password_resets_request_spec.rb
+++ b/spec/requests/password_resets_request_spec.rb
@@ -2,84 +2,84 @@ require 'rails_helper'
 
 RSpec.describe "PasswordResets", type: :request do
 
-  let(:user) { create(:user) }
-  before { user.create_reset_digest }
+  # let(:user) { create(:user) }
+  # before { user.create_reset_digest }
 
-  describe "GET /new" do
-    it "returns http success" do
-      get new_password_reset_path
-      expect(response).to have_http_status(:success)
-    end
-  end
+  # describe "GET /new" do
+  #   it "returns http success" do
+  #     get new_password_reset_path
+  #     expect(response).to have_http_status(:success)
+  #   end
+  # end
 
-  describe "GET /edit" do
-    context "メールアドレスが無効な場合" do
-      it "redirects to root_path" do
-        get edit_password_reset_path(user.reset_token, email: "")
-        expect(response).to redirect_to root_path
-      end
-    end
+  # describe "GET /edit" do
+  #   context "メールアドレスが無効な場合" do
+  #     it "redirects to root_path" do
+  #       get edit_password_reset_path(user.reset_token, email: "")
+  #       expect(response).to redirect_to root_path
+  #     end
+  #   end
 
-    context "ユーザーが無効な場合" do
-      it "redirects to root_path" do
-        user.toggle!(:activated)
-        get edit_password_reset_path(user.reset_token, email: user.email)
-        expect(response).to redirect_to root_path
-      end
-    end
+  #   context "ユーザーが無効な場合" do
+  #     it "redirects to root_path" do
+  #       user.toggle!(:activated)
+  #       get edit_password_reset_path(user.reset_token, email: user.email)
+  #       expect(response).to redirect_to root_path
+  #     end
+  #   end
 
-    context "メールアドレスが有効でトークンが無効な場合" do
-      it "redirects to root_path" do
-        get edit_password_reset_path('wrong token', email: user.email)
-        expect(response).to redirect_to root_path
-      end
-    end
+  #   context "メールアドレスが有効でトークンが無効な場合" do
+  #     it "redirects to root_path" do
+  #       get edit_password_reset_path('wrong token', email: user.email)
+  #       expect(response).to redirect_to root_path
+  #     end
+  #   end
 
-    context "メールアドレス・トークンが有効な場合" do
-      it "redirects to root_path" do
-        get edit_password_reset_path(user.reset_token, email: user.email)
-        expect(response).to have_http_status(:success)
-      end
-    end
-  end
+  #   context "メールアドレス・トークンが有効な場合" do
+  #     it "redirects to root_path" do
+  #       get edit_password_reset_path(user.reset_token, email: user.email)
+  #       expect(response).to have_http_status(:success)
+  #     end
+  #   end
+  # end
 
-  context "ログイン中の場合" do
-    before do
-      log_in_as user
-    end
+  # context "ログイン中の場合" do
+  #   before do
+  #     log_in_as user
+  #   end
 
-    describe "GET/ new" do
-      it "root_pathにリダイレクトする" do
-        get new_password_reset_path
-        expect(response).to redirect_to root_path
-      end
-    end
+  #   describe "GET/ new" do
+  #     it "root_pathにリダイレクトする" do
+  #       get new_password_reset_path
+  #       expect(response).to redirect_to root_path
+  #     end
+  #   end
 
-    describe "GET/ edit" do
-      it "root_pathにリダイレクトする" do
-          get edit_password_reset_path(user.reset_token, email: user.email)
-          expect(response).to redirect_to root_path
-      end
-    end
-  end
+  #   describe "GET/ edit" do
+  #     it "root_pathにリダイレクトする" do
+  #         get edit_password_reset_path(user.reset_token, email: user.email)
+  #         expect(response).to redirect_to root_path
+  #     end
+  #   end
+  # end
 
-  context "ゲストログイン中の場合" do
-    before do
-      guest_login
-    end
+  # context "ゲストログイン中の場合" do
+  #   before do
+  #     guest_login
+  #   end
 
-    describe "GET/ new" do
-      it "root_pathにリダイレクトする" do
-        get new_password_reset_path
-        expect(response).to redirect_to root_path
-      end
-    end
+  #   describe "GET/ new" do
+  #     it "root_pathにリダイレクトする" do
+  #       get new_password_reset_path
+  #       expect(response).to redirect_to root_path
+  #     end
+  #   end
 
-    describe "GET/ edit" do
-      it "root_pathにリダイレクトする" do
-          get edit_password_reset_path(user.reset_token, email: user.email)
-          expect(response).to redirect_to root_path
-      end
-    end
-  end
+  #   describe "GET/ edit" do
+  #     it "root_pathにリダイレクトする" do
+  #         get edit_password_reset_path(user.reset_token, email: user.email)
+  #         expect(response).to redirect_to root_path
+  #     end
+  #   end
+  # end
 end


### PR DESCRIPTION
## 変更の概要

* password_reset関係のルーティングのリファクタリング

## なぜこの変更をするのか

* 不要箇所の削除

## やったこと

* [x] password_controllerが担っていたnew, editアクションをapi/controllerに移行
* [x] routes.rbにpassword_resets/new及び/editにアクセスがあった際はapi/password_resets#new, editに割り振るよう設定
* [x] password_resets controllerのedit以外のアクションを削除(自動送信メールにeditパスを仕込む関係でeditは消せない）
* [x] password_resets のmailer文章編集
* [x] password_resets controller rspecを削除
* [x] api/password_resets controller rspecにnew, editアクションをテストする項目を追加.
* [x] routes.rbに可読性向上のためのコメントを追加