### PR TITLE
fix: comment postion on routes.rb

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,6 @@
 Rails.application.routes.draw do
-  
-　#vue-routerで設定したurlをapi/controllerに割り振り
+
+  #vue-routerで設定したurlをapi/controllerに割り振り
   get '/contacts', to: 'api/contacts#new'
   get '/users/new', to: 'api/users#new'
   get '/users/:id', to: 'api/users#show'


### PR DESCRIPTION
## 変更の概要

* routes.rbのコメント場所調整

## なぜこの変更をするのか

* herokuデプロイ時に発生したエラー対処

## やったこと

* [x] routes.rbのトップに記述したコメント箇所がインデントが途切れていたため場所を修正