### PR TITLE
ナビゲーションガードの設定

### DIFF
--- a/app/controllers/api/password_resets_controller.rb
+++ b/app/controllers/api/password_resets_controller.rb
@@ -54,7 +54,6 @@ class Api::PasswordResetsController < ApplicationController
      # トークンが期限切れかどうか確認する
      def check_expiration
         if @user.password_reset_expired?
-          # flash[:danger] = "Password reset has expired."
           response_bad_request
         end
       end

--- a/app/controllers/api/users_controller.rb
+++ b/app/controllers/api/users_controller.rb
@@ -2,7 +2,7 @@ class Api::UsersController < ApplicationController
   before_action :set_user, only: [:show, :update]
   before_action :logged_in_user, only: [:index, :show, :edit, :update, :destroy]
   before_action :correct_user, only: [:show, :edit, :update, :destroy]
-  before_action :not_guest_user, only: [:index, :show, :create, :edit, :update, :destroy]
+  before_action :not_guest_user, only: [:index, :show, :create, :update, :destroy]
 
   def index
     @users = User.all

--- a/app/javascript/src/router.js
+++ b/app/javascript/src/router.js
@@ -14,7 +14,6 @@ import Courses from './answers/Courses.vue'
 import Answers from './answers/Index.vue'
 import AnswerEdit from './answers/Edit.vue'
 import Questions from './questions/Admin.vue'
-import QuestionNew from './questions/New.vue'
 import Dictionary from './dictionaries/Dictionary.vue'
 
 export const router = createRouter({
@@ -47,32 +46,56 @@ export const router = createRouter({
       beforeEnter: (to, from, next) => {
         if (store.state.loggedIn) next()
         else next({name: 'login'})
+        if (store.state.notGuest) next()
+        else next({name: 'home'})
       }
     },
     {
       path: '/users/new',
       name: 'new',
       component: New,
+      beforeEnter: (to, from, next) => {
+        if (store.state.loggedIn) next({name: 'home'})
+        else next()
+      }
     },
     {
       path: '/users/:id/edit',
       name: 'change info',
       component: userEdit,
+      beforeEnter: (to, from, next) => {
+        if (store.state.loggedIn) next()
+        else next({name: 'login'})
+        if (store.state.notGuest) next()
+        else next({name: 'home'})
+      }
     },
     {
       path: '/login',
       name: 'login',
       component: Login,
+      beforeEnter: (to, from, next) => {
+        if (store.state.loggedIn) next({name: 'home'})
+        else next()
+      }
     },
     {
       path: '/password_resets/new',
       name: 'reset',
       component: Reset,
+      beforeEnter: (to, from, next) => {
+        if (store.state.loggedIn) next({name: 'home'})
+        else next()
+      }
     },
     {
       path: '/password_resets/:reset_token/edit',
       name: 'change',
       component: Change,
+      beforeEnter: (to, from, next) => {
+        if (store.state.loggedIn) next({name: 'home'})
+        else next()
+      }
     },
     {
       path: '/api/account_activation/:activation_token/edit',
@@ -96,6 +119,8 @@ export const router = createRouter({
       beforeEnter: (to, from, next) => {
         if (store.state.loggedIn) next()
         else next({name: 'login'})
+        if (store.state.notGuest) next()
+        else next({name: 'home'})
       }
     },
     {
@@ -105,17 +130,18 @@ export const router = createRouter({
       beforeEnter: (to, from, next) => {
         if (store.state.loggedIn) next()
         else next({name: 'login'})
+        if (store.state.notGuest) next()
+        else next({name: 'home'})
       }
-    },
-    {
-      path: '/questions/new',
-      name: 'questionNew',
-      component: QuestionNew
     },
     {
       path: '/admin_page',
       name: 'adminPage',
-      component: Questions
+      component: Questions,
+      beforeEnter: (to, from, next) => {
+        if (store.state.admin) next()
+        else next({name: 'home'})
+      }
     },
     {
       path: '/users/:id/dictionaries',
@@ -124,6 +150,8 @@ export const router = createRouter({
       beforeEnter: (to, from, next) => {
         if (store.state.loggedIn) next()
         else next({name: 'login'})
+        if (store.state.notGuest) next()
+        else next({name: 'home'})
       }
     }
   ],


### PR DESCRIPTION
## 変更の概要

* vue-routerへのナビゲーションガード設定

## なぜこの変更をするのか

* ページ遷移時の検証を強化するため

## やったこと
全てvue-router上の記述
* [x] /users/:idにユーザーがゲストではないことを検証するガードを設定
* [x]/users/:id/edit にユーザーがログインしていること、ゲストではないことを検証するガードを設定
* [x]/users/newにユーザーがログインしていないことを検証するガードを設定
* [x]/loginにユーザーがログインしていないことを検証するガードを設定
* [x]/users/:id/answersにユーザーがゲストではないことを検証するガードを設定
* [x]/users/:id/answers/:id/editにユーザーがログインしていること、ゲストではないことを検証するガードを設定
* [x]/courseにユーザーがログインしていることを検証するガードを設定
* [x]/password_resets/newにユーザーがログインしていないことを検証するガードを設定
* [x]/password_resets/:reset_token/editにユーザーがログインしていないことを検証するガードを設定
* [x]/admin_pageにユーザーが管理ユーザーであることを検証するガードを設定
* [x]/dictionariesにユーザーがログインしていること、ゲストではないことを検証するガードを設定