### PR TITLE
correct user バリデーションのセット

### DIFF
--- a/app/javascript/src/answers/Edit.vue
+++ b/app/javascript/src/answers/Edit.vue
@@ -47,6 +47,7 @@
     },
     mounted() {
       this.getAnswer();
+      this.correctUser();
     },
     methods: {
       //answerのデータを受け取るメソッド
@@ -74,7 +75,13 @@
             });
           })
         }
+      },
+      correctUser: function(){
+      const currentUserId = this.$store.state.userId
+      if(!(currentUserId == this.$route.params.user_id)){
+        this.$router.push({name: 'home'})
       }
+    }
     }
   }
 </script>

--- a/app/javascript/src/answers/Index.vue
+++ b/app/javascript/src/answers/Index.vue
@@ -35,6 +35,7 @@
     },
     mounted() {
       this.getAnswers();
+      this.correctUser();
     },
     methods: {
       //特定日付のanswer一覧のデータを受け取るメソッド
@@ -47,7 +48,13 @@
         .then(response => {
           this.answers = response.data.answers
         })
+      },
+      correctUser: function(){
+      const currentUserId = this.$store.state.userId
+      if(!(currentUserId == this.$route.params.id)){
+        this.$router.push({name: 'home'})
       }
+    }
     }
   }
 </script>

--- a/app/javascript/src/users/Edit.vue
+++ b/app/javascript/src/users/Edit.vue
@@ -43,6 +43,7 @@
     },
     mounted() {
       this.setUser();
+      this.correctUser();
     },
     methods: {
       //ログイン中のユーザー情報を取得するメソッド
@@ -73,7 +74,13 @@
             time: 3000
           });
         })
+      },
+      correctUser: function(){
+      const currentUserId = this.$store.state.userId
+      if(!(currentUserId == this.$route.params.id)){
+        this.$router.push({name: 'home'})
       }
+    }
     }
   }
 </script>


### PR DESCRIPTION
## 変更の概要

* ログイン済みのユーザーが異なるユーザーの情報を閲覧することを防ぐ

## なぜこの変更をするのか

* ページ遷移上のセキュリティ強化

## やったこと

* [x] users/ Edit.vueに遷移時にstore.state.userIdとパラメーターのuser_idを照合し、異なればホーム画面に遷移するメソッドを設定
* [x] answers/Index.vueに上記と同じメソッドを設定
* [x] answers/Edit.vueに上記と同じメソッドを設定