### PR TITLE
refactor: account activation controller

### DIFF
--- a/app/controllers/account_activations_controller.rb
+++ b/app/controllers/account_activations_controller.rb
@@ -1,14 +1,12 @@
 class AccountActivationsController < ApplicationController
-  # def edit
-  #   user = User.find_by(email: params[:email])
-  #   if user && !user.activated? && user.authenticated?(:activation, params[:id])
-  #     user.activate
-  #     log_in user
-  #     flash[:success] = "SelfTalkEnglishへようこそ！"
-  #     redirect_to root_path
-  #   else
-  #     flash[:danger] = "無効なリンクです。"
-  #     redirect_to root_path
-  #   end
-  # end
+  
+  def edit
+    user = User.find_by(email: params[:email])
+    if user && !user.activated? && user.authenticated?(:activation, params[:id])
+      user.activate
+      redirect_to login_path
+    else
+      redirect_to root_path
+    end
+  end
 end

--- a/app/controllers/api/account_activations_controller.rb
+++ b/app/controllers/api/account_activations_controller.rb
@@ -1,12 +1,12 @@
 class Api::AccountActivationsController < ApplicationController
-  
-  def edit
-    user = User.find_by(email: params[:email])
-    if user && !user.activated? && user.authenticated?(:activation, params[:id])
-      user.activate
-      redirect_to login_path
-    else
-      redirect_to root_path
-    end
-  end
+
+  # def edit
+  #   user = User.find_by(email: params[:email])
+  #   if user && !user.activated? && user.authenticated?(:activation, params[:id])
+  #     user.activate
+  #     redirect_to login_path
+  #   else
+  #     redirect_to root_path
+  #   end
+  # end
 end

--- a/app/views/user_mailer/account_activation.html.erb
+++ b/app/views/user_mailer/account_activation.html.erb
@@ -6,5 +6,5 @@
 　ご登録頂きありがとうございます。現在は仮登録状態です。下記URLからログインを行ってください。
 </p>
 
-<%= link_to "ログインを行う", edit_api_account_activation_url(@user.activation_token,
+<%= link_to "ログインを行う", edit_account_activation_url(@user.activation_token,
                                                     email: @user.email) %>

--- a/app/views/user_mailer/account_activation.text.erb
+++ b/app/views/user_mailer/account_activation.text.erb
@@ -2,4 +2,4 @@ Hi <%= @user.name %>,
 
 Welcome to SelfTalkEnglish! Click on the link below to activate your account:
 
-<%= edit_api_account_activation_url(@user.activation_token, email: @user.email) %>
+<%= edit_account_activation_url(@user.activation_token, email: @user.email) %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -16,6 +16,8 @@ Rails.application.routes.draw do
   get '/password_resets/:reset_token/edit', to: 'static_pages#home'
   get '/admin_page', to: 'static_pages#home'
   get '/course', to: 'static_pages#home'
+  resources :account_activations, only: [:edit]
+  resources :password_resets, only: [:edit]
 
   # get '/contacts', to: 'api/contacts#new'
   # get '/users/new', to: 'api/users#new'
@@ -30,8 +32,6 @@ Rails.application.routes.draw do
   # get '/users/:id/answers', to: 'api/answers#index'
   # get '/users/:id/answers/:id/edit', to: 'api/answers#edit'
 
-  resources :account_activations, only: [:edit]
-  resources :password_resets, only: [:edit]
 
 
 
@@ -73,14 +73,7 @@ Rails.application.routes.draw do
     resources :password_resets, only: [:new, :create, :edit, :update]
   end
 
-  namespace :api do
-    resources :account_activations, only: [ :edit ]
-  end
-
   namespace :api, format: 'json' do
     resources :questions
   end
-
-
-
 end

--- a/spec/requests/account_activations_request_spec.rb
+++ b/spec/requests/account_activations_request_spec.rb
@@ -1,1 +1,39 @@
+require 'rails_helper'
 
+RSpec.describe "AccountActivations", type: :request do
+  let(:user) { create(:user, :no_activated) }
+
+  context "トークンは有効だがメールアドレスが無効な場合" do
+
+    before do
+      get edit_account_activation_path(
+        user.activation_token,
+        email: 'wrong')
+    end
+
+    it "ログイン時にエラー401を返す" do
+      expect(response).to redirect_to root_path
+      post api_login_path, params: { session: { email: user.email,
+      password: 'password' } }
+      expect(response).to have_http_status "401"
+    end
+  end
+
+  context "有効なトークンと有効なメールアドレスが送信された場合" do
+
+   before do
+     get edit_account_activation_path(
+        user.activation_token,
+        email: user.email,
+      )
+    end
+
+    it "ログイン画面に遷移し、レスポンス200を返す" do
+      expect(response).to redirect_to login_path
+      post api_login_path, params: { session: { email: user.email,
+        password: 'password' } }
+        expect(response).to have_http_status "200"
+    end
+  end
+
+end

--- a/spec/requests/api/account_activation_request_spec.rb
+++ b/spec/requests/api/account_activation_request_spec.rb
@@ -1,39 +1,39 @@
-require 'rails_helper'
+# require 'rails_helper'
 
-RSpec.describe "Api::AccountActivations", type: :request do
-  let(:user) { create(:user, :no_activated) }
+# RSpec.describe "Api::AccountActivations", type: :request do
+#   let(:user) { create(:user, :no_activated) }
 
-  context "トークンは有効だがメールアドレスが無効な場合" do
+#   context "トークンは有効だがメールアドレスが無効な場合" do
 
-    before do
-      get edit_api_account_activation_path(
-        user.activation_token,
-        email: 'wrong')
-    end
+#     before do
+#       get edit_api_account_activation_path(
+#         user.activation_token,
+#         email: 'wrong')
+#     end
 
-    it "ログイン時にエラー401を返す" do
-      expect(response).to redirect_to root_path
-      post api_login_path, params: { session: { email: user.email,
-      password: 'password' } }
-      expect(response).to have_http_status "401"
-    end
-  end
+#     it "ログイン時にエラー401を返す" do
+#       expect(response).to redirect_to root_path
+#       post api_login_path, params: { session: { email: user.email,
+#       password: 'password' } }
+#       expect(response).to have_http_status "401"
+#     end
+#   end
 
-  context "有効なトークンと有効なメールアドレスが送信された場合" do
+#   context "有効なトークンと有効なメールアドレスが送信された場合" do
 
-   before do
-     get edit_api_account_activation_path(
-        user.activation_token,
-        email: user.email,
-      )
-    end
+#    before do
+#      get edit_api_account_activation_path(
+#         user.activation_token,
+#         email: user.email,
+#       )
+#     end
 
-    it "ログイン画面に遷移し、レスポンス200を返す" do
-      expect(response).to redirect_to login_path
-      post api_login_path, params: { session: { email: user.email,
-        password: 'password' } }
-        expect(response).to have_http_status "200"
-    end
-  end
+#     it "ログイン画面に遷移し、レスポンス200を返す" do
+#       expect(response).to redirect_to login_path
+#       post api_login_path, params: { session: { email: user.email,
+#         password: 'password' } }
+#         expect(response).to have_http_status "200"
+#     end
+#   end
 
-end
+# end


### PR DESCRIPTION
## 変更の概要

* api/account_activations controllerをコメントアウト

## なぜこの変更をするのか

* account_activations controllerに関してはapiモードで設定する必要がないため

## やったこと

* [x] api/account_activations controllerを全てコメントアウト
* [x]account_activations controllerにapiモードコントローラーの内容をコピペ
* [x] routes.rb からapi/account_activationsのルーティングを削除
* [x] api/account_activations のrspecを全てコメントアウト
* [x]　account_activations controllerにapiモードのrspecの内容をコピペ

