### PR TITLE
feat: 404 error handling

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -71,7 +71,7 @@ class ApplicationController < ActionController::Base
 
   #error handling
 
-  rescue_from Exception, with: :error500
+  rescue_from Exception, with: :error404
   rescue_from ActiveRecord::RecordNotFound,
   ActionController::RoutingError, with: :error404
 

--- a/app/javascript/src/components/Header.vue
+++ b/app/javascript/src/components/Header.vue
@@ -70,61 +70,73 @@
       nav1: String,
       nav2: String
     },
+    mounted() {
+      this.notFoundPage();
+    },
     methods: {
       //logoutメソッド
-       destroySession: function() {
-          axios.delete('/api/logout')
-          .then(response => {
-            this.$store.commit('logout'),
-            this.$store.commit('removeId'),
-            this.$router.push({ path: '/'}),
-            this.$flashMessage.show({
-              type: 'success',
-              title: 'Logout',
-              text:'ログアウトしました',
-              time: 3000
-            });
-          })
-          .catch(error => {
-            this.$flashMessage.show({
-              type: 'error',
-              text: 'ログアウトできませんでした',
-              time: 3000
-            });
-          })
-        },
-        //退会メソッド
-       deleteUser: function(id) {
-          if(window.confirm('データが全て削除されますが退会しますか？')) {
-          axios.delete('/api/users/' + id)
-          .then(response => {
+      destroySession: function() {
+        axios.delete('/api/logout')
+        .then(response => {
           this.$store.commit('logout'),
           this.$store.commit('removeId'),
           this.$router.push({ path: '/'}),
           this.$flashMessage.show({
             type: 'success',
-            title: '退会',
-            text: '退会しました',
-            time: 3000
-          })
-          .catch(err => {
-          this.$flashMessage.show({
-            type: 'error',
-            text: 'エラーが発生しました',
+            title: 'Logout',
+            text:'ログアウトしました',
             time: 3000
           });
         })
-      })
-    }
-  },
+        .catch(error => {
+          this.$flashMessage.show({
+            type: 'error',
+            text: 'ログアウトできませんでした',
+            time: 3000
+          });
+        })
+      },
+      //退会メソッド
+      deleteUser: function(id) {
+        if(window.confirm('データが全て削除されますが退会しますか？')) {
+        axios.delete('/api/users/' + id)
+        .then(response => {
+         this.$store.commit('logout'),
+         this.$store.commit('removeId'),
+         this.$router.push({ path: '/'}),
+         this.$flashMessage.show({
+           type: 'success',
+           title: '退会',
+           text: '退会しました',
+           time: 3000
+         })
+        .catch(err => {
+          this.$flashMessage.show({
+           type: 'error',
+           text: 'エラーが発生しました',
+           time: 3000
+          });
+        })
+       })
+       }
+      },
       //ハンバーガーメニューメソッド
       showMenu: function() {
         document.getElementById('line1').classList.toggle('line_1');
         document.getElementById('line2').classList.toggle('line_2');
         document.getElementById('line3').classList.toggle('line_3');
         document.getElementById('nav').classList.toggle('in');
-        }
+      },
+      //ルーティングエラー時に専用のコンポーネントへ遷移する
+      notFoundPage: function() {
+        axios.get(location.pathname)
+        .catch(error => {
+          if(error.response.status === 404) {
+            this.$router.push({name: 'Error'})
+          }
+        })
       }
+    }
   }
 </script>
 

--- a/app/javascript/src/pages/Error.vue
+++ b/app/javascript/src/pages/Error.vue
@@ -1,5 +1,11 @@
 <template>
-  <h1 class="text-white text-3xl">指定されたページは存在しません・</h1>
+  <div class="text-white text-3xl text-center">
+    <h1 class="mb-8">404 NOT FOUND</h1>
+    <p class="mb-36">お探しのページは一時的にアクセスができない状況にあるか、移動もしくは削除された可能性があります。 また、URL、ファイル名にタイプミスがないか再度ご確認ください。</p>
+    <router-link :to="{ name: 'home' }" class="underline hover:text-blue-500">
+      HOME画面に戻る
+    </router-link>
+  </div>
 </template>
 
 <script>

--- a/app/javascript/src/router.js
+++ b/app/javascript/src/router.js
@@ -140,7 +140,7 @@ export const router = createRouter({
       }
     },
     {
-      path: '/*',
+      path: '/404NotFound',
       name: 'Error',
       component: Error
     }

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -77,5 +77,5 @@ Rails.application.routes.draw do
     resources :questions
   end
 
-  match '*path', :to => 'static_pages#home', :via => :all
+  match '*path', :to => 'application#error404', :via => :all
 end


### PR DESCRIPTION
## 変更の概要

* routing errorのハンドリング

## なぜこの変更をするのか

* 設定されていないパスにアクセスされた際のハンドリング

## やったこと

* [x]routes.rbに/*path（設定外のルート）にアクセスされた際はapplication#error404(404レスポンスを返すメソッド）を実行するよう設定
* [x]application_controllerに404のレスポンスを返すメソッドを追加
* [x]router.jsに/notfoundパスを追加し、404レスポンスを検知した際に呼び出すError.vueのルーティングを設定
* [x]pages/Error.vue componentを作成。home画面へのリンクを搭載
* [x]components/Header.vueに現在のパスにアクセスし、404エラーを返した場合のみ、Error.vueへ遷移するメソッドを追加