### PR TITLE
fix: add js tag to home.html.erb

### DIFF
--- a/app/views/static_pages/home.html.erb
+++ b/app/views/static_pages/home.html.erb
@@ -1,3 +1,4 @@
+<%= javascript_pack_tag 'application' %>
 <% provide(:title, 'home') %>
 
 


### PR DESCRIPTION
## 変更の概要

* home.html.erbにjavascript tag追加

## なぜこの変更をするのか

* ec2デプロイ時のjs読み込まないエラー対応

## やったこと

* [x] views/static_pages/home.html.erbに<% javascript_pack_tag 'application' %>追加