### PR TITLE
fix: add index.css for tailwind

### DIFF
--- a/app/javascript/allVue/index.js
+++ b/app/javascript/allVue/index.js
@@ -4,6 +4,7 @@ import { router } from '../src/router';
 import FlashMessage from '@smartweb/vue-flash-message';
 import { store } from '../src/store.js';
 import SetInterval from '../src/plugins/SetInterval';
+import '../src/index.css';
 
 
 

--- a/app/javascript/src/index.css
+++ b/app/javascript/src/index.css
@@ -1,0 +1,3 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;


### PR DESCRIPTION
## 変更の概要

* index.cssに追加

## なぜこの変更をするのか

* vue templateに本番環境でtailwindを読み込めないエラー対応

## やったこと

* [x] src配下にindex.cssを追加
* [x] index.cssに@tailwind base;
@tailwind components;
@tailwind utilities;を追加
* [x] allVue/index.jsにindex.cssをimport