### PR TITLE
notice model作成

### DIFF
--- a/app/assets/stylesheets/custom.scss
+++ b/app/assets/stylesheets/custom.scss
@@ -534,7 +534,6 @@
   font-weight: bold;
 }
 
-
 .admin-title {
  margin-top: 24px;
  margin-bottom: 24px;
@@ -556,6 +555,10 @@
   border-color: rgb(156, 141, 141);
   border-radius: 0.25rem;
   font-size: 1.5rem;
+}
+
+.question-list-style {
+  list-style: none;
 }
 
 .question-delete {

--- a/app/javascript/src/App.vue
+++ b/app/javascript/src/App.vue
@@ -1,7 +1,7 @@
 <template>
   <main>
     <Header nav1="ログイン" nav2="新規登録"/>
-    <div class="contents">
+    <div class="flex-grow p-24">
       <FlashMessage position="left top"/>
       <router-view />
     </div>

--- a/app/javascript/src/questions/Admin.vue
+++ b/app/javascript/src/questions/Admin.vue
@@ -27,7 +27,7 @@
 
       <!-- 出題文一覧 -->
       <div v-for="question in questions" class="question-list" :key="question">
-        <li class="list-none">
+        <li class="question-list-style">
           {{question.content}}
           <button @click="deleteQuestion(question.id)" class="question-delete">
             削除

--- a/app/models/notice.rb
+++ b/app/models/notice.rb
@@ -1,0 +1,4 @@
+class Notice < ApplicationRecord
+  validates :title, presence: true, length: {maximum: 255}
+  validates :content, presence: true, length: {maximum: 255}
+end

--- a/db/migrate/20211222113836_create_notices.rb
+++ b/db/migrate/20211222113836_create_notices.rb
@@ -1,0 +1,10 @@
+class CreateNotices < ActiveRecord::Migration[6.0]
+  def change
+    create_table :notices do |t|
+      t.text :title
+      t.text :content
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_11_17_113110) do
+ActiveRecord::Schema.define(version: 2021_12_22_113836) do
 
   create_table "answers", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3", force: :cascade do |t|
     t.text "content"
@@ -38,6 +38,13 @@ ActiveRecord::Schema.define(version: 2021_11_17_113110) do
     t.string "meaning"
     t.text "memo"
     t.index ["user_id"], name: "index_items_on_user_id"
+  end
+
+  create_table "notices", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3", force: :cascade do |t|
+    t.text "title"
+    t.text "content"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
   end
 
   create_table "questions", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3", force: :cascade do |t|

--- a/spec/factories/notices.rb
+++ b/spec/factories/notices.rb
@@ -1,0 +1,6 @@
+FactoryBot.define do
+  factory :notice do
+    title { "MyText" }
+    content { "MyText" }
+  end
+end

--- a/spec/models/notice_spec.rb
+++ b/spec/models/notice_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe Notice, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end


### PR DESCRIPTION
## 変更の概要

* Noticeモデルの作成

## なぜこの変更をするのか

* お知らせ通知機能実装のため

## やったこと

* [x] notice modelをgenerate, カラムはtitleとcontentの二つで両方ともtext型
* [x] db をmigerate
* [x] notice.rbにtitleとcontentのpresenceをtrueにし、マックス255文字とした