### PR TITLE
notice controllerの作成

### DIFF
--- a/app/controllers/api/notices_controller.rb
+++ b/app/controllers/api/notices_controller.rb
@@ -1,0 +1,18 @@
+class Api::NoticesController < ApplicationController
+  before_action :admined_user, only: [:show, :show, :create, :destroy]
+
+  def index
+  end
+
+  def show
+  end
+
+  def create
+  end
+
+  def destroy
+  end
+
+
+
+end

--- a/app/helpers/api/notices_helper.rb
+++ b/app/helpers/api/notices_helper.rb
@@ -1,0 +1,2 @@
+module Api::NoticesHelper
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -77,5 +77,9 @@ Rails.application.routes.draw do
     resources :questions
   end
 
+  namespace :api, format: 'json' do
+    resources :notices, only: [:index, :show, :create, :destroy]
+  end
+
   match '*path', :to => 'application#error404', :via => :all
 end

--- a/spec/helpers/api/notices_helper_spec.rb
+++ b/spec/helpers/api/notices_helper_spec.rb
@@ -1,0 +1,15 @@
+require 'rails_helper'
+
+# Specs in this file have access to a helper object that includes
+# the Api::NoticesHelper. For example:
+#
+# describe Api::NoticesHelper do
+#   describe "string concat" do
+#     it "concats two strings with spaces" do
+#       expect(helper.concat_strings("this","that")).to eq("this that")
+#     end
+#   end
+# end
+RSpec.describe Api::NoticesHelper, type: :helper do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/requests/api/notices_request_spec.rb
+++ b/spec/requests/api/notices_request_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe "Api::Notices", type: :request do
+
+end


### PR DESCRIPTION
## 変更の概要

* api/notices_controller作成

## なぜこの変更をするのか

* お知らせ通知機能実装のため

## やったこと

* [x] api/notices_controllerをgenerate(show, index, create, destroyアクションを記述）
* [x] routes.rbにapi/notices_controllerの上記アクションのルーティング設定
