### PR TITLE
test: api/notices_controller rspec

### DIFF
--- a/app/controllers/api/items_controller.rb
+++ b/app/controllers/api/items_controller.rb
@@ -1,6 +1,6 @@
 class Api::ItemsController < ApplicationController
   before_action :set_user, only: [:index, :create, :destroy]
-  before_action :logged_in_user
+  before_action :logged_in_user, only: [:index, :create, :destroy]
   before_action :not_guest_user, only: [:index, :create, :destroy]
 
   #items一覧表示機能

--- a/app/controllers/api/notices_controller.rb
+++ b/app/controllers/api/notices_controller.rb
@@ -1,5 +1,7 @@
 class Api::NoticesController < ApplicationController
   before_action :admined_user, only: [:create, :destroy]
+  before_action :logged_in_user, only: [:index, :show, :create, :destroy]
+  before_action :not_guest_user, only: [:index, :show, :create, :destroy]
 
   def index
     @notices = Notice.all

--- a/app/javascript/src/App.vue
+++ b/app/javascript/src/App.vue
@@ -1,7 +1,7 @@
 <template>
   <main>
     <Header />
-    <div class="contents">
+    <div class="flex-grow p-24">
       <FlashMessage position="left top"/>
       <router-view />
     </div>

--- a/spec/helpers/api/notices_helper_spec.rb
+++ b/spec/helpers/api/notices_helper_spec.rb
@@ -10,6 +10,6 @@ require 'rails_helper'
 #     end
 #   end
 # end
-RSpec.describe Api::NoticesHelper, type: :helper do
-  pending "add some examples to (or delete) #{__FILE__}"
-end
+# RSpec.describe Api::NoticesHelper, type: :helper do
+#   pending "add some examples to (or delete) #{__FILE__}"
+# end

--- a/spec/requests/api/items_request_spec.rb
+++ b/spec/requests/api/items_request_spec.rb
@@ -27,7 +27,7 @@ RSpec.describe "Api::Items", type: :request do
         end
       end
       context "item追加欄に空欄がある場合" do
-        it "answerが保存されずレスポンス400を返す" do
+        it "noticeが保存されずレスポンス400を返す" do
           expect{
           post api_items_path, params:
           {id: user.id, item: {content: "", meaning:"test", memo:"test"}}

--- a/spec/requests/api/notices_request_spec.rb
+++ b/spec/requests/api/notices_request_spec.rb
@@ -1,5 +1,157 @@
 require 'rails_helper'
 
 RSpec.describe "Api::Notices", type: :request do
+  let!(:user){create(:user, :admin)}
+  let!(:notice){create(:notice)}
 
+  context "ログイン済みユーザーが管理者の場合" do
+    before do
+      log_in_as user
+    end
+
+    describe "GET /index" do
+      it "成功レスポンス200を返す" do
+        get api_notices_path
+        expect(response).to have_http_status "200"
+      end
+    end
+
+    describe "GET /show" do
+      it "成功レスポンス200を返す" do
+        get api_notice_path(notice)
+        expect(response).to have_http_status "200"
+      end
+    end
+
+    describe "POST /create" do
+      context "noticeが空欄ではない場合" do
+        it "noticeを保存しレスポンス200を返す" do
+          expect{
+          post api_notices_path, params:
+          { notice: {title: "test", content: "test"}}
+          }.to change(Notice, :count).by(1)
+          expect(response).to have_http_status "200"
+        end
+      end
+
+      context "notice追加欄に空欄がある場合" do
+        it "noticeが保存されずレスポンス400を返す" do
+          expect{
+          post api_notices_path, params:
+          { notice: {title: "", content: ""}}
+          }.to change(Notice, :count).by(0)
+          expect(response).to have_http_status "400"
+        end
+      end
+    end
+
+    describe "Delete /destroy" do
+      it "成功レスポンス200を返す" do
+        expect{
+        delete api_notice_path(notice), params: {id: notice.id}
+        }.to change(Notice, :count).by(-1)
+        expect(response).to have_http_status "200"
+      end
+    end
+  end
+
+  context "ログイン済みユーザーが管理者ではない場合" do
+    let(:user){create(:user)}
+    before do
+      log_in_as user
+    end
+
+    describe "POST /create" do
+      it "noticeを保存せずroot_pathにリダイレクトする" do
+        expect{
+        post api_notices_path, params:
+        { notice: {title: "test", content: "test"}}
+        }.to change(Notice, :count).by(0)
+        expect(response).to redirect_to root_path
+      end
+    end
+
+    describe "Delete /destroy" do
+      it "root_pathにリダイレクトする" do
+        expect{
+        delete api_notice_path(notice), params: {id: notice.id}
+        }.to change(Notice, :count).by(0)
+        expect(response).to redirect_to root_path
+      end
+    end
+  end
+
+  context "ログイン済みでないユーザーの場合" do
+    describe "GET /index" do
+      it "login_pathにリダイレクト" do
+        get api_notices_path
+        expect(response).to redirect_to login_path
+      end
+    end
+
+    describe "GET /show" do
+      it "login_pathにリダイレクト" do
+        get api_notice_path(notice)
+        expect(response).to redirect_to login_path
+      end
+    end
+
+    describe "POST /create" do
+      it "noticeは生成されず、login_pathにリダイレクトする" do
+        expect{
+          post api_notices_path, params:
+          {notice: {titel: "test", content: "test"}}
+          }.to change(Notice, :count).by(0)
+          expect(response).to redirect_to login_path
+      end
+    end
+
+    describe "Delete /destroy" do
+      it "noticeは削除されず、login_pathにリダイレクトする" do
+        expect{
+          delete api_notice_path(notice), params: {id: notice.id}
+        }.to change(Notice, :count).by(0)
+        expect(response).to redirect_to login_path
+      end
+    end
+  end
+
+  context "ゲストログイン中の場合" do
+    before do
+      guest_login
+    end
+
+    describe "GET /index" do
+      it "root_pathにリダイレクトする" do
+        get api_notices_path
+        expect(response).to redirect_to root_path
+      end
+    end
+
+    describe "GET /show" do
+      it "root_pathにリダイレクトする" do
+        get api_notice_path(notice)
+        expect(response).to redirect_to root_path
+      end
+    end
+
+    describe "POST /create" do
+      it "noticeは生成されず、root_pathにリダイレクトする" do
+        expect{
+          post api_notices_path, params:
+          {notice: {title: "test", content: "test"}}
+          }.to change(Notice, :count).by(0)
+          expect(response).to redirect_to root_path
+      end
+    end
+
+    describe "Delete /destroy" do
+      it "noticeは削除されず、root_pathにリダイレクトする" do
+        expect{
+          delete api_notice_path(notice), params: {id: notice.id}
+        }.to change(Notice, :count).by(0)
+        expect(response).to redirect_to root_path
+      end
+    end
+  end
 end


### PR DESCRIPTION
## 変更の概要

* api/notices_controllerのrspec追加

## なぜこの変更をするのか

* お知らせ通知機能のテストのため

## やったこと

* [x] api/notices_controllerのrspecを追加
* [x] ログインユーザーが管理者の場合、ログインユーザーが管理者ではない場合、ユーザーがログインしていない場合、ユーザーがゲストユーザーの場合にわけてテスト追加