### PR TITLE
fix: validation for guest user on notices path

### DIFF
--- a/app/javascript/src/notices/Index.vue
+++ b/app/javascript/src/notices/Index.vue
@@ -29,6 +29,7 @@
   },
   mounted() {
     this.getNotices();
+    this.checkNotGuestUser();
   },
   methods: {
     getNotices: function() {
@@ -51,9 +52,12 @@
           })
         })
       }
+    },
+    checkNotGuestUser: function() {
+      if(this.$store.state.guest){
+        this.$router.push({name: 'home'})
+      }
     }
   }
-
-
 }
 </script>


### PR DESCRIPTION
## 変更の概要

* guestユーザーのお知らせページへのアクセスを無効にする

## なぜこの変更をするのか

* バリデーションの漏れがあったため

## やったこと

* [x] notices/Index.vueにguest userのアクセスがあった際はルートパスへ誘導するメソッドを追加