### PR TITLE
fix: errors rubocop tells

### DIFF
--- a/app/controllers/api/guest_logins_controller.rb
+++ b/app/controllers/api/guest_logins_controller.rb
@@ -1,13 +1,13 @@
 class Api::GuestLoginsController < ApplicationController
 
   def guest_sign_in
-    user = User.find_or_create_by!(email: 'guest@example.com') do |user|
-      user.name = "ゲストユーザー"
-      user.password = SecureRandom.urlsafe_base64
+    @guest_user = User.find_or_create_by!(email: 'guest@example.com') do |guest_user|
+      guest_user.name = "ゲストユーザー"
+      guest_user.password = SecureRandom.urlsafe_base64
     end
 
     if !logged_in?
-      log_in user
+      log_in @guest_user
       response_success(:user, :guest_sign_in)
     else
       response_bad_request

--- a/app/controllers/api/password_resets_controller.rb
+++ b/app/controllers/api/password_resets_controller.rb
@@ -48,10 +48,10 @@ class Api::PasswordResetsController < ApplicationController
       end
     end
 
-     # トークンが期限切れかどうか確認する
-     def check_expiration
-        if @user.password_reset_expired?
-          response_bad_request
-        end
+    # トークンが期限切れかどうか確認する
+    def check_expiration
+      if @user.password_reset_expired?
+        response_bad_request
       end
+    end
 end

--- a/spec/requests/api/answers_request_spec.rb
+++ b/spec/requests/api/answers_request_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe "Answers", type: :request do
   context "ログイン済みユーザーの場合" do
       before do
         log_in_as user
-        questions = create_list(:question, 10)
+        create_list(:question, 10)
       end
 
       describe "GET/ index" do


### PR DESCRIPTION
## 変更の概要

* rubocopが発したw以上の警告一部修正

## なぜこの変更をするのか

* rubocopでw以上の警告があったため

## やったこと

* [x] api/guest_logins controllerで変数の被りがあったため変数名変更
* [x] api/answers request specで使用していない変数名があったため削除
* [x] api/password_resets controllerでインデントの位置が他とずれているものがあったため修正