### PR TITLE
fix: errors rubocop tells

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -75,7 +75,7 @@ class ApplicationController < ActionController::Base
   rescue_from ActiveRecord::RecordNotFound,
   ActionController::RoutingError, with: :error404
 
-  def error404(e)
+  def error404
     render "error404", status: 404
   end
 

--- a/spec/requests/api/questions_request_spec.rb
+++ b/spec/requests/api/questions_request_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe "Api::Questions", type: :request do
           expect{
             post api_questions_path ,params: { question:
             {content: "test", mode_num: 1}}
-            }.to change(Question, :count).by (1)
+            }.to change(Question, :count).by(1)
             expect(response).to have_http_status "200"
         end
       end
@@ -30,7 +30,7 @@ RSpec.describe "Api::Questions", type: :request do
         it "エラーレスポンス400を返す" do
           expect{
             post api_questions_path ,params: { question: {content: "", mode_num: ""}}
-            }.to change(Question, :count).by (0)
+            }.to change(Question, :count).by(0)
             expect(response).to have_http_status "400"
         end
       end
@@ -65,7 +65,7 @@ RSpec.describe "Api::Questions", type: :request do
         expect{
           post api_questions_path ,params: { question:
           {content: "test", mode_num: 1}}
-          }.to change(Question, :count).by (0)
+          }.to change(Question, :count).by(0)
           expect(response).to redirect_to root_path
       end
     end
@@ -93,7 +93,7 @@ RSpec.describe "Api::Questions", type: :request do
         expect{
           post api_questions_path ,params: { question:
           {content: "test", mode_num: 1}}
-          }.to change(Question, :count).by (0)
+          }.to change(Question, :count).by(0)
           expect(response).to redirect_to login_path
       end
     end


### PR DESCRIPTION
## 変更の概要

* rubocop で検出した警告の修正

## なぜこの変更をするのか

* rubocopでw以上の警告がでたため
## やったこと

* [x] application_controllerのerror404を発するメソッドの引数が無駄に定義されていたため削除
* [x] api/questions request specのコードに無駄な空白がある箇所があったのでそこを埋めた