### PR TITLE
tailwindcssの記述削除

### DIFF
--- a/app/assets/stylesheets/custom.scss
+++ b/app/assets/stylesheets/custom.scss
@@ -1,4 +1,12 @@
 //overall
+.wrapper {
+  display: flex;
+  flex-direction: column;
+  --tw-bg-opacity: 1;
+  background-color: rgba(30, 58, 138, var(--tw-bg-opacity));
+  min-height: 100vh;
+
+}
 
 .contents {
   @media screen and (min-width: 960px) {
@@ -1123,6 +1131,7 @@
   margin-left: 24px;
   margin-top: 32px;
   transform: scale(2);
+  z-index: -1;
 }
 
 

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -7,19 +7,19 @@
     <meta name="viewport"
     content="width=device-width,initial-scale=1.0,minimum-scale=1.0">
 
-    <%= stylesheet_link_tag "inter-font" %>
-    <%= stylesheet_link_tag "tailwind" %>
+    <!--tailwindを記載はしていないが下記タグを付けないとレイアウトが崩れる-->
     <%= stylesheet_link_tag "inter-font", "data-turbo-track": "reload" %>
     <%= stylesheet_link_tag "tailwind", "data-turbo-track": "reload" %>
     <%= stylesheet_link_tag 'application', media: 'all' %>
     <%= javascript_pack_tag 'application' %>
+    
     <!--[if lt IE 9]>
      <script src="//cdnjs.cloudflare.com/ajax/libs/html5shiv/r29/html5.min.js">
      </script>
     <![endif]-->
   </head>
 
-  <body class="bg-blue-900 flex flex-col min-h-screen">
+  <body class="wrapper">
     <div id="application"></div>
   </body>
 </html>


### PR DESCRIPTION
## 変更の概要

* bodyタグに設定されていたtailwindをcustom.scssに移行

## なぜこの変更をするのか

* tailwindを一部使っていると統一感がないため

## やったこと

* [x] views/layouts/application.html.erbのbodyタグに記載されていたtailwindをcustom.scssに移行
* [x] Dictionary.Vueのcheckboxがメインメニューにかぶっていたのでz-index: -1を設定
