### PR TITLE
style: replace textarea tags

### DIFF
--- a/app/assets/stylesheets/custom.scss
+++ b/app/assets/stylesheets/custom.scss
@@ -1098,7 +1098,11 @@
 }
 
 .items-column {
-  padding: 16px;
+  @media screen and ( max-width: 480px) {
+    font-size: 0.75rem;
+    height: 50px;
+  }
+  padding: 8px;
   width: 320px;
   height: 80px;
   background-color: #ffffff;
@@ -1106,13 +1110,15 @@
   border-width: 1px;
   border-color: #000000;
   resize: none;
-  appearance: none;
-  -moz-appearance: none;
-  -webkit-appearance: none;
 }
 
 .items-memo {
-  padding: 16px;
+  @media screen and ( max-width: 480px) {
+    font-size: 0.5rem;
+    height: 50px;
+    padding: 4px;
+  }
+  padding: 8px;
   width: 400px;
   height: 80px;
   background-color: #ffffff;
@@ -1121,9 +1127,6 @@
   border-color: #000000;
   overflow-wrap: break-word;
   resize: none;
-  appearance: none;
-  -moz-appearance: none;
-  -webkit-appearance: none;
 }
 
 .items-delete {
@@ -1166,18 +1169,16 @@
 }
 
 .answer-text-content {
-  background-color: white;
-  color: black;
-  width: 100%;
-  resize: none;
   padding: 8px;
+  width: 100%;
+  height: 100%;
+  color: black;
+  background-color: white;
+  resize: none;
   border-width: 1px;
   border-style: solid;
   border-color: black;
   border-radius: 0.5rem;
-  appearance: none;
-  -moz-appearance: none;
-  -webkit-appearance: none;
 }
 
 .question-content {

--- a/app/javascript/src/answers/Index.vue
+++ b/app/javascript/src/answers/Index.vue
@@ -5,16 +5,17 @@
     </h1>
     <MyMenu />
 
-    <div v-for="answer in answers" class="answers" :key="answer">
-      <textarea v-model="answer.content" disabled class="answer-text-content">
-      </textarea>
+    <section v-for="answer in answers" class="answers" :key="answer">
+      <div class="answer-text-content">
+        {{answer.content}}
+      </div>
       <li class="edit-btn">
        <router-link :to="{name: 'answerEdit', params: {user_id: $store.state.userId,
        id: answer.id}}">
          添削する
        </router-link>
       </li>
-    </div>
+    </section>
   </div>
 
 </template>

--- a/app/javascript/src/dictionaries/Dictionary.vue
+++ b/app/javascript/src/dictionaries/Dictionary.vue
@@ -12,19 +12,19 @@
     </div>
 
     <!-- 保存した単語・フレーズ一覧表示 -->
-    <div v-for="item in items" :key="item" class="items">
-      <textarea v-model="item.content" disabled class="items-column"></textarea>
+    <section v-for="item in items" :key="item" class="items">
+      <div class="items-column">{{item.content}}</div>
 
-      <textarea v-model="item.meaning" disabled class="items-column"></textarea>
+      <div class="items-column">{{item.meaning}}</div>
 
-      <textarea v-model="item.memo" disabled class="items-memo"></textarea>
+      <div class="items-memo">{{item.memo}}</div>
 
       <button @click="deleteItem(item.id)" class="items-delete">
         削除
       </button>
 
       <input type="checkbox" class="checkbox">
-    </div>
+    </section>
   </div>
 
 </template>


### PR DESCRIPTION
## 変更の概要

* textarea tagの変更

## なぜこの変更をするのか

* textareaタグを使用するとiphoneのサファリで閲覧した際に影がかかるため

## やったこと

* [x] answers/Index.vue, dictionaries/Dictionary.vueのtextarea tagをdivタグへ変更