### PR TITLE
feat: generate google login controller

### DIFF
--- a/app/controllers/social_logins_controller.rb
+++ b/app/controllers/social_logins_controller.rb
@@ -1,0 +1,16 @@
+class SocialLoginsController < ApplicationController
+
+  def create
+    if (user = User.find_or_create_from_auth_hash(auth_hash))
+      log_in user
+    end
+    redirect_to root_path
+  end
+
+  private
+
+  def auth_hash
+    request.env['omniauth.auth']
+  end
+  
+end

--- a/app/javascript/src/pages/Home.vue
+++ b/app/javascript/src/pages/Home.vue
@@ -56,6 +56,8 @@
         ゲストログイン</button>
       </div>
 
+      <!-- <button @click="googleLogin">Google login</button> -->
+
       <div class="home-div">
         <router-link to="/about" class="home-link-about">"独り言英語学習"とは</router-link>
       </div>
@@ -106,6 +108,9 @@
             time: 3000
           })
         });
+      },
+      googleLogin: function () {
+        axios.post('/auth/google_oauth2')
       }
     }
   }

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -73,6 +73,13 @@ class User < ApplicationRecord
     reset_sent_at < 2.hours.ago
   end
 
+  def find_or_create_from_auth_hash(auth_hash)
+    user_params = user_params_from_auth_hash(auth_hash)
+    find_or_create_by(email: user_params[:email]) do |user|
+      user.update(user_params)
+    end
+  end
+
   private
 
     # メールアドレスをすべて小文字にする
@@ -84,6 +91,14 @@ class User < ApplicationRecord
     def create_activation_digest
       self.activation_token  = User.new_token
       self.activation_digest = User.digest(activation_token)
+    end
+
+    def user_params_from_auth_hash(auth_hash)
+      {
+        name: auth_hash.info.name,
+        email: auth_hash.info.email,
+        image: auth_hash.info.image,
+      }
     end
 end
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -22,6 +22,8 @@ Rails.application.routes.draw do
   resources :password_resets, only: [:edit]
 
 
+  post 'auth/:provider/callback', to: 'social_logins#create'
+
 
 
 

--- a/spec/requests/social_logins_request_spec.rb
+++ b/spec/requests/social_logins_request_spec.rb
@@ -1,0 +1,12 @@
+# require 'rails_helper'
+
+# RSpec.describe "SocialLogins", type: :request do
+
+#   describe "POST /create" do
+#     it "returns http success" do
+#       post "/social_logins/create"
+#       expect(response).to have_http_status(:success)
+#     end
+#   end
+
+# end


### PR DESCRIPTION
## 変更の概要

* google login用のコントローラー作成・設定

## なぜこの変更をするのか

* Googleログイン機能実装のため

## やったこと

* [x] google_logins controllerをgenerate
* [x] 上記コントローラーにcreateアクションだけ設定
* [x] createアクションにGoogleログイン画面へ遷移するためのコード記載
* [x] routes.rbに上記アクションのルーティング記載
* [x] components/Home.vueにGoogleログインを行うメソッドを設定。ひとまずコメントアウト