### PR TITLE
style: display course name on answer edit

### DIFF
--- a/app/assets/stylesheets/answers.scss
+++ b/app/assets/stylesheets/answers.scss
@@ -174,10 +174,16 @@
 
 //answer-edit
 
+
 .answer-edit-wrapper {
   justify-content: center;
   align-items: center;
   text-align: center;
+}
+
+.from-course-name {
+  font-size: 1.5rem;
+  color: #ffffff;
 }
 
 .edit-save-btn {

--- a/app/javascript/src/answers/Edit.vue
+++ b/app/javascript/src/answers/Edit.vue
@@ -3,9 +3,12 @@
 
     <MyMenu />
 
-    <h1 class="question-display">
-      Q. {{question.content}}
+    <h1 class="from-course-name">
+      From {{course}}
     </h1>
+    <h2 class="question-display">
+      Q. {{question.content}}
+    </h2>
 
     <textarea v-model="answer.content" class="answer-input-form" >
     </textarea>
@@ -37,6 +40,7 @@
         answer: {
           content: ""
         },
+        course: "",
         date: ""
       }
     },
@@ -51,6 +55,13 @@
         ${this.$route.params.id}/edit`)
         .then(response => {
           this.question = response.data.question
+          if(this.question.mode_num == 1) {
+            this.course = "Self Explain"
+          } if (this.question.mode_num == 2) {
+            this.course = "Self Reaction"
+          } if (this.question.mode_num == 3) {
+            this.course = "Self translation"
+          }
           this.answer= response.data
           this.date = response.data.date
         })

--- a/app/javascript/src/pages/Home.vue
+++ b/app/javascript/src/pages/Home.vue
@@ -107,9 +107,6 @@
             time: 3000
           })
         });
-      },
-      googleLogin: function () {
-        axios.post('/auth/google_oauth2')
       }
     }
   }

--- a/app/views/api/answers/edit.json.jbuilder
+++ b/app/views/api/answers/edit.json.jbuilder
@@ -1,7 +1,7 @@
 json.(@answer, :content, :created_at)
 
 json.question do
-  json.(@question, :content)
+  json.(@question, :content, :mode_num)
 end
 
 json.date @date


### PR DESCRIPTION
## 変更の概要

* answers/Edit.vueに出題文がどのコースかを表示する

## なぜこの変更をするのか

* UX向上
## やったこと

* [x] answers/Edit.vueのquestionを取得するメソッド内でそのquestionのmode_numによってコース名を動的に表示するよう実装
* [x] views/api/answers/edit.json.jbuilderにquestionのmode_numも受け取るよう追記
* [x] Home.vueにgoogle.loginメソッドの残骸か残っていたので削除
* [x] answers.scssにコース名の表示のcssを記載