### PR TITLE
fix: remove host setting on default of database.yml

### DIFF
--- a/config/database.yml
+++ b/config/database.yml
@@ -16,7 +16,6 @@ default: &default
   username: root
   password: yuya0216
   socket: /tmp/mysql.sock
-  host: db
 
 
 development:


### PR DESCRIPTION
## 変更の概要

* database.ymlのデフォルト設定の変更

## なぜこの変更をするのか

* デフォルト設定にhostを追加したところproduction環境でhostを設定していなかったためデプロイ時にエラーがでたため
## やったこと

* [x] database.ymlのdefault からhostを削除