### PR TITLE
feat: create helper to count sequential learning days

### DIFF
--- a/app/controllers/api/users_controller.rb
+++ b/app/controllers/api/users_controller.rb
@@ -1,4 +1,5 @@
 class Api::UsersController < ApplicationController
+  include UsersHelper
   before_action :set_user, only: [:update]
   before_action :logged_in_user, only: [:index, :show, :edit, :update, :destroy]
   before_action :correct_user, only: [:show, :edit, :update, :destroy]
@@ -13,6 +14,7 @@ class Api::UsersController < ApplicationController
     @user = current_user
     @dates = current_user.answers.map{|dates| dates.created_at.to_date}.uniq
     @learning_days = @dates.count
+    # @learning_days = sequential_days
     #MyPage.vueで曜日毎のanswerを取り出す際に~月~日の'月日'を弾くために（）を付けている
     @wdays = ['(月)','(火)','(水)','(木)','(金)','(土)','(日)']
     @contributions = current_user.answers.created_in_a_week

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -86,4 +86,6 @@ class ApplicationController < ActionController::Base
     render "error500", status: 500
   end
 
+
+
 end

--- a/app/helpers/users_helper.rb
+++ b/app/helpers/users_helper.rb
@@ -1,0 +1,17 @@
+module UsersHelper
+
+  def sequential_days
+    yesterday = Time.zone.yesterday
+    today = Time.zone.today
+    sequential_record = current_user.answers.where(:created_at  => yesterday .. )
+    if sequential_record.nil?
+      @sequential_days = 0
+    else
+      @sequential_days = current_user.answers.where(:created_at  => today .. )
+      @sequential_days = @sequential_days.map{|dates| dates.created_at.to_date}.uniq
+      @sequential_days = @sequential_days.count
+    end
+  end
+
+
+end

--- a/app/javascript/src/users/Index.vue
+++ b/app/javascript/src/users/Index.vue
@@ -10,7 +10,7 @@
 
     <!--user一覧を表示する -->
     <li v-for="user in users" :key="user" class="user-list">
-      {{user.name}}
+      {{user.name}} : {{user.email}}
     </li>
   </div>
 </template>


### PR DESCRIPTION
## 変更の概要

* 連続学習日数をカウントするためのヘルパーメソッド実装

## なぜこの変更をするのか

* 連続学習日数表示機能実装のため

## やったこと

* [x] users_helper.rbを作成
* [x] 昨日以降に作成されたanswerがない場合、連続学習日数のインスタンスに0,ある場合は今日以降にanswerが作成された日数を代入するよう実装