### PR TITLE
feat: display sequential learning days on MyPage.vue

### DIFF
--- a/app/assets/stylesheets/users.scss
+++ b/app/assets/stylesheets/users.scss
@@ -30,6 +30,10 @@
   padding-left: 16px;
 }
 
+.sequential-learning-day {
+  margin-top: 16px;
+}
+
 .learning-day {
   padding-top: 32px;
   width: 96px;
@@ -52,6 +56,7 @@
 }
 
 .contribution{
+  margin-top: 36px;
   margin-left: 48px;
 }
 

--- a/app/controllers/api/users_controller.rb
+++ b/app/controllers/api/users_controller.rb
@@ -14,7 +14,7 @@ class Api::UsersController < ApplicationController
     @user = current_user
     @dates = current_user.answers.map{|dates| dates.created_at.to_date}.uniq
     @learning_days = @dates.count
-    # @learning_days = sequential_days
+    @sequential_days = sequential_days
     #MyPage.vueで曜日毎のanswerを取り出す際に~月~日の'月日'を弾くために（）を付けている
     @wdays = ['(月)','(火)','(水)','(木)','(金)','(土)','(日)']
     @contributions = current_user.answers.created_in_a_week

--- a/app/javascript/src/users/MyPage.vue
+++ b/app/javascript/src/users/MyPage.vue
@@ -10,9 +10,14 @@
     <div class="learning-status">
 
       <div class="contribution">
-        <p class="learning-day-p">学習日数</p>
+        <p class="learning-day-p">総学習日数</p>
         <section class="learning-day">
           {{learningDays}}日
+        </section>
+
+        <p class="sequential-learning-day">連続学習日数</p>
+        <section class="learning-day">
+          {{sequentialDays}}日
         </section>
       </div>
 
@@ -65,6 +70,7 @@
       user: "",
       dates: "",
       learningDays: "",
+      sequentialDays: "",
       days: "",
       contributions: ""
     }
@@ -82,6 +88,7 @@
         this.user = response.data
         this.dates = response.data.dates //answerの作成された日付の配列
         this.learningDays = response.data.learning //学習日数
+        this.sequentialDays = response.data.sequential_days //連続学習日数
         this.days = response.data.days //曜日の配列
         this.contributions = response.data.contributions //answerの作成された数の配列
       })

--- a/app/views/api/users/show.json.jbuilder
+++ b/app/views/api/users/show.json.jbuilder
@@ -2,6 +2,8 @@ json.(@user, :name , :email, :password, :password_confirmation)
 
 json.learning @learning_days
 
+json.sequential_days @sequential_days
+
 json.dates do
   json.array! @dates
 end


### PR DESCRIPTION
## 変更の概要

* MyPage.vueに連続学習日数を表示

## なぜこの変更をするのか

* バックエンドで実装した箇所のフロントエンドへの反映

## やったこと

* [x] views/api/users/show.json.jbuilderに連続学習日数データを受け取るよう追記
* [x] users/MyPage.vueに連続学習日数を表示するよう追記
* [x] 上記実装のcss追加