### PR TITLE
fix: sequential learning days

### DIFF
--- a/app/helpers/users_helper.rb
+++ b/app/helpers/users_helper.rb
@@ -3,15 +3,13 @@ module UsersHelper
   def sequential_days
     yesterday = Time.zone.yesterday
     today = Time.zone.today
-    sequential_record = current_user.answers.where(:created_at  => yesterday .. )
-    if sequential_record.nil?
+    sequential_records = current_user.answers.where(:created_at => yesterday ..  )
+    if sequential_records.nil?
       @sequential_days = 0
     else
-      @sequential_days = current_user.answers.where(:created_at  => today .. )
-      @sequential_days = @sequential_days.map{|dates| dates.created_at.to_date}.uniq
+      @sequential_days = sequential_records.map{|dates| dates.created_at.to_date}.uniq
       @sequential_days = @sequential_days.count
     end
   end
-
 
 end


### PR DESCRIPTION
## 変更の概要

* 連続学習日数表示機能修正

## なぜこの変更をするのか

* 連続記録をカウントするメソッドに誤りがあったため
## やったこと

* [x] users_helper.rbのsequential_daysの条件分岐修正