### PR TITLE
fix: sequential days function works

### DIFF
--- a/app/controllers/api/questions_controller.rb
+++ b/app/controllers/api/questions_controller.rb
@@ -1,10 +1,18 @@
 class Api::QuestionsController < ApplicationController
+  include UsersHelper
   before_action :admined_user, only: [:index, :create, :destroy]
 
   def index
     @questions1 = Question.where(mode_num: 1) #explain course
     @questions2 = Question.where(mode_num: 2) #reaction course
     @questions3 = Question.where(mode_num: 3) #translate course
+  end
+
+  def new
+    # questionとは関係ないコードだが単に@today_answersをCourse.vueで参照したいだけ
+    #他のコントローラーのアクションでは余計なDB通信が発生したりするため余っていたこれを利用
+    @today_answers = today_answers.count
+    render json: @today_answers
   end
 
   def create

--- a/app/controllers/api/users_controller.rb
+++ b/app/controllers/api/users_controller.rb
@@ -14,7 +14,7 @@ class Api::UsersController < ApplicationController
     @user = current_user
     @dates = current_user.answers.map{|dates| dates.created_at.to_date}.uniq
     @learning_days = @dates.count
-    @sequential_days = sequential_days
+    @yesterday_answer = yesterday_answer.count
     #MyPage.vueで曜日毎のanswerを取り出す際に~月~日の'月日'を弾くために（）を付けている
     @wdays = ['(月)','(火)','(水)','(木)','(金)','(土)','(日)']
     @contributions = current_user.answers.created_in_a_week

--- a/app/helpers/users_helper.rb
+++ b/app/helpers/users_helper.rb
@@ -1,15 +1,13 @@
 module UsersHelper
 
-  def sequential_days
+  def yesterday_answer
     yesterday = Time.zone.yesterday
-    today = Time.zone.today
-    sequential_records = current_user.answers.where(:created_at => yesterday ..  )
-    if sequential_records.nil?
-      @sequential_days = 0
-    else
-      @sequential_days = sequential_records.map{|dates| dates.created_at.to_date}.uniq
-      @sequential_days = @sequential_days.count
-    end
+    yesterday_answer = current_user.answers.where(:created_at => yesterday ..  )
+  end
+
+  def today_answers
+    today = Time.zone.now
+    today_answers = current_user.answers.where(created_at: today.all_day)
   end
 
 end

--- a/app/javascript/src/answers/Courses.vue
+++ b/app/javascript/src/answers/Courses.vue
@@ -46,12 +46,14 @@
         answer: {
           content: ""
         },
-        mode_num: this.$route.query.mode_num
+        mode_num: this.$route.query.mode_num,
+        answersCreatedToday: ""
       }
     },
     mounted() {
       this.getRandomQuestion();
       this.startTimer();
+      this.getAnswersCreatedToday();
     },
     methods: {
       getRandomQuestion: function () {
@@ -72,6 +74,9 @@
           this.getRandomQuestion();
           this.$clearInterval(this.$intervals);
           this.startTimer();
+          if(this.answersCreatedToday === 0){
+            this.$store.commit('countSequentialDays')
+          }
         })
          .catch(err => {
             this.answer.content = ""
@@ -91,6 +96,12 @@
             clearInterval(this.$intervals);
           }
       }, 1000)
+     },
+     getAnswersCreatedToday: function () {
+       axios.get('/api/questions/new')
+       .then(response => {
+         this.answersCreatedToday = response.data
+       })
      }
     }
   }

--- a/app/javascript/src/store.js
+++ b/app/javascript/src/store.js
@@ -10,7 +10,8 @@ export const store = createStore ({
       notGuest: true,
       guest: false,
       userId: 0,
-      unreadNotice: false
+      unreadNotice: false,
+      sequentialDays: 0
     }
   },
   mutations: {
@@ -52,6 +53,9 @@ export const store = createStore ({
     //お知らせ一覧ページを既読にする
     readNotice: (state) => {
       state.unreadNotice = false
+    },
+    countSequentialDays: (state) => {
+      state.sequentialDays = +1
     }
   },
   plugins : [

--- a/app/javascript/src/users/MyPage.vue
+++ b/app/javascript/src/users/MyPage.vue
@@ -17,7 +17,7 @@
 
         <p class="sequential-learning-day">連続学習日数</p>
         <section class="learning-day">
-          {{sequentialDays}}日
+          {{$store.state.sequentialDays}}日
         </section>
       </div>
 
@@ -70,9 +70,10 @@
       user: "",
       dates: "",
       learningDays: "",
-      sequentialDays: "",
       days: "",
-      contributions: ""
+      contributions: "",
+      answerCreatedYesterday: ""
+
     }
   },
   mounted() {
@@ -88,9 +89,12 @@
         this.user = response.data
         this.dates = response.data.dates //answerの作成された日付の配列
         this.learningDays = response.data.learning //学習日数
-        this.sequentialDays = response.data.sequential_days //連続学習日数
         this.days = response.data.days //曜日の配列
         this.contributions = response.data.contributions //answerの作成された数の配列
+        this.answerCreatedYesterday = response.data.answerCreatedYesterday //連続学習日数
+        if(this.answerCreatedYesterday === 0) {
+          this.$store.state.sequentialDays = 0
+        }
       })
     }
   }

--- a/app/views/api/answers/new.json.jbuilder
+++ b/app/views/api/answers/new.json.jbuilder
@@ -1,1 +1,0 @@
-json.(@question, :content, :mode_num)

--- a/app/views/api/questions/new.json.jbuilder
+++ b/app/views/api/questions/new.json.jbuilder
@@ -1,0 +1,1 @@
+json.answersCreatedToday @today_answers

--- a/app/views/api/users/show.json.jbuilder
+++ b/app/views/api/users/show.json.jbuilder
@@ -2,7 +2,7 @@ json.(@user, :name , :email, :password, :password_confirmation)
 
 json.learning @learning_days
 
-json.sequential_days @sequential_days
+json.answerCreatedYesterday @yesterday_answer
 
 json.dates do
   json.array! @dates

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -61,7 +61,7 @@ Rails.application.routes.draw do
   end
 
   namespace :api, format: 'json' do
-    resources :questions, only: [:index, :create, :destroy]
+    resources :questions, only: [:index, :new, :create, :destroy]
   end
 
   namespace :api, format: 'json' do


### PR DESCRIPTION
## 変更の概要

* 連続学習記録カウント機能をvuexを用いて再構成

## なぜこの変更をするのか

* rails側だけの実装だとうまくいかなかったため

## やったこと

* [x] vuexにsequentialDaysという連続学習記録を保存するstateを設定
* [x] MyPage.vueの連続学習記録日数には上記stateを参照するよう設定
* [x] MyPage.vueアクセス時にuser/showアクションで昨日から今日にかけて作成されたanswerの数を確認し、0であれば日数を0にリセットするよう実装
* [x] Courses.vueでanswer作成時にsequentialDaysを＋１カウントするよう追加
* [x] api/questions newアクションに今日作成されたanswerの数を返す変数を設定し、Courses.vueの上記メソッド実行時、中身が0の時にカウントを行うよう設定
* [x]なぜquestion controllerにその変数を設定したかというと余分にコントローラーを追加するよりスマートと思った