### PR TITLE
fix: export method mounted on answers/Edit.vue

### DIFF
--- a/app/javascript/src/answers/Edit.vue
+++ b/app/javascript/src/answers/Edit.vue
@@ -48,7 +48,7 @@
     },
     mounted() {
       this.getInfoAboutAnswer();
-      Export.mksureCorrectUser(this.$route.params.id);
+      Export.mksureCorrectUser(this.$route.params.user_id);
       Export.mksureNotGuestUser();
     },
     methods: {


### PR DESCRIPTION
## 変更の概要

* amswers/Edit.vueのexportメソッドの引数修正 
## なぜこの変更をするのか

* バグのため

## やったこと

* [x] answers/Edit.vueのmksureCorrectUser()の引数にidではなくuser_idを設定