### PR TITLE
fix: remove conpressor from config/enviroments/production

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -23,7 +23,7 @@ Rails.application.configure do
   config.public_file_server.enabled = ENV['RAILS_SERVE_STATIC_FILES'].present?
 
   # Compress CSS using a preprocessor.
-  config.assets.css_compressor = :purger
+ 
 
   # Do not fallback to assets pipeline if a precompiled asset is missed.
   config.assets.compile = true


### PR DESCRIPTION
## 変更の概要

*  config.assets.css_compressor = :purgerを削除
## なぜこの変更をするのか

* 自動デプロイに失敗したため
## やったこと

* [x]  config.assets.css_compressor = :purgerを削除