### PR TITLE
doc: fix fingerprints on circleci config

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -90,7 +90,7 @@ jobs:
          path: ~/selftalk_app   # Git コードをプルダウンします。
       - ruby/install-deps # Ruby Orb を使って依存関係をインストールします。
       - add_ssh_keys:
-          fingerprints: SHA256:Nygwji3iGTwnKKIPmqbkWoN77aj9dyHN1VjUQWKnM6s
+          fingerprints: 3d:17:e1:b5:04:cf:93:1e:da:af:75:b4:a6:ea:cc:c4
       - run:
           name: 自動デプロイ
           command: bundle exec cap production deploy


### PR DESCRIPTION
## 変更の概要

* circleci ssh keyのfingerprints設定値を修正
## なぜこの変更をするのか

* 自動デプロイに失敗したため

## やったこと

* [x] fingerprintsをcircleci のページに記載されているものに置き換え