### PR TITLE
refactor: replace some code to model file on ansers controller

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -76,7 +76,7 @@ jobs:
           command: bundle exec rspec
       - run:
           name: Rubocop
-          command: bundle exec  rubocop --fail-level W --display-only-fail-level-offenses
+          command: bundle exec  rubocop --fail-level W --display-only-fail-level-offenses  # warning以上の警告があればstopをかける
 
   deploy:
     docker:
@@ -100,11 +100,11 @@ jobs:
 workflows:
   version: 2
   build_and_test_and_deploy:
-    jobs:             # このワークフローの一部として実行するジョブのリストです。
-      - build         # まず、ビルドを実行します。
-      - test:         # 次に、テストを実行します。
-          requires:   # テストを実行するにはビルドを渡す必要があります。
-            - build   # 最後に、ビルドしたジョブを実行します。
+    jobs:
+      - build
+      - test:
+          requires:
+            - build
       - deploy:
           requires:
             - test

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 # 使用技術
 
 * Ruby 3.0.2
-* Ruby on Rails 6.0,4
+* Ruby on Rails 6.0.4
 * MySQL 5.7
 * Vue.js 3（SPA化）
 * Docker

--- a/app/controllers/api/answers_controller.rb
+++ b/app/controllers/api/answers_controller.rb
@@ -3,15 +3,12 @@ class Api::AnswersController < ApplicationController
   before_action :not_guest_user, only: [:index, :edit, :update]
 
   def index
-    #scopeを使ってmodelに移したが動作しなかったのでこちらに戻した
-    @answers = current_user.answers.where(["created_at Like ?",
-    "%#{params[:created_at]}%"])
+    @answers = current_user.answers.all_created_at_the_date(params[:created_at])
   end
 
   def new
-    @questions = Question.where(mode_num: params[:mode_num])
-    #pluckを用いると比較的ランダム性が正確になる
-    @question = @questions.find(@questions.pluck(:id).sample)
+    @questions = Question.of_selected_mode(params[:mode_num])
+    @question = @questions.randomly_selected(@questions)
     render json: @question
   end
 

--- a/app/models/answer.rb
+++ b/app/models/answer.rb
@@ -5,5 +5,8 @@ class Answer < ApplicationRecord
   default_scope -> { order(created_at: :desc) }
 
   scope :created_in_a_week, -> { where(created_at: Time.current.all_week) }
+  scope :all_created_at_the_date, -> (params){where(["created_at Like ?", "%#{params}%"])}
+  # @answers = current_user.answers.where(["created_at Like ?",
+  #   "%#{params[:created_at]}%"])
 
 end

--- a/app/models/question.rb
+++ b/app/models/question.rb
@@ -3,5 +3,7 @@ class Question < ApplicationRecord
   validates :content, presence: true, length: {maximum: 255}
   validates :mode_num, presence: true
 
-  scope :get_questions, -> (params){where(params)}
+  scope :of_selected_mode, -> (params){where(mode_num: params)}
+  #pluckを用いると比較的ランダム性が正確になる
+  scope :randomly_selected, -> (questions){find(questions.pluck(:id).sample)}
 end


### PR DESCRIPTION
## 変更の概要

* api/answers_controllerの記述をいくつかscopeとしてmodelに記述

## なぜこの変更をするのか

* 可読性向上のため

## やったこと

* [x] api/answers_controllerのwhere メソッドをanswers.rbとquestions.rbにscopeとして移管
* [x] README.mdにタイポがあったので修正（railsのversion表記）
* [x] .circleci/config.ymlのrubocopの命令にコメント追加