### PR TITLE
fix: deep L api setting

### DIFF
--- a/app/controllers/api/translations_controller.rb
+++ b/app/controllers/api/translations_controller.rb
@@ -2,17 +2,21 @@ class Api::TranslationsController < ApplicationController
   require 'httpclient'
 
   def translate
+    # @answer = current_user.answers.find(params[:id])
     api_key = Rails.application.credentials.deepl[:api_key]
-    url = "https://api-free.deepl.com/v2/translate"
+    uri = "https://api-free.deepl.com/v2/translate"
     client = HTTPClient.new
     query = {
       auth_key: api_key,
-      text: "This is a test",
+      text: "this is an answer",
       target_lang: "JA"
     }
-    @response = client.get(url, params: query)
+    headers = {
+      Authorization: api_key
+    }
+    @response = client.get(uri, body: query, header: headers)
 
-    render json: @response
+    render json: @response.body
 
 
   end

--- a/app/javascript/src/answers/Edit.vue
+++ b/app/javascript/src/answers/Edit.vue
@@ -92,8 +92,8 @@
       translateWithDeepL: function() {
         axios.get('/api/translate')
         .then(response => {
-          this.result = response.data
-          console.log(response.data)
+          this.result = response.data.translations[0].text
+          console.log(response.data.translations[0].text)
         })
       }
     }

--- a/app/views/api/answers/edit.json.jbuilder
+++ b/app/views/api/answers/edit.json.jbuilder
@@ -6,4 +6,4 @@ end
 
 json.date @date
 
-json.deeplKey @deepl_api_key
+

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -70,7 +70,6 @@ Rails.application.routes.draw do
   namespace :api, format: 'json' do
     get '/translate', to: 'translations#translate'
   end
-  get '/api-free.deepl.com/v2/translate', to: 'api/translations#translate'
 
   match '*path', :to => 'application#error404', :via => :all
 end


### PR DESCRIPTION
## 変更の概要

* DeepL apiにgetリクエストを送信して、正しくresponseを受け取るための実装

## なぜこの変更をするのか

* deep L api導入のため

## やったこと

* [x] api/translate controllerにauthorizationのresponse headerを追加
* [x] answers/Edit.vueのdeepl apiを叩くメソッドのレスポンス受け取りコードを編集