### PR TITLE
Translation courseに翻訳結果表示機能追加(DeepL api)

### DIFF
--- a/app/assets/stylesheets/answers.scss
+++ b/app/assets/stylesheets/answers.scss
@@ -235,7 +235,36 @@
   }
 }
 
+//DeepL api関係 (translation course内のcss)
 .result {
+  padding: 4px;
+  height: 50px;
   background-color: #ffffff;
+  border-style: solid;
+  border-width: 1px;
+  border-radius: 0.25rem;
+  text-align: left;
+}
+
+.access-deepl-btn {
+  padding-top: 8px;
+  padding-bottom: 8px;
+  padding-right: 16px;
+  padding-left: 16px;
+  margin-top: 40px;
+  margin-bottom: 40px;
+  margin-left: 16px;
+  color: #ffffff;
+  --tw-bg-opacity: 1;
+  background-color: rgba(37, 99, 235, var(--tw-bg-opacity));
+  border-width: 1px;
+  --tw-border-opacity: 1;
+  border-color: #ffffff;
+  border-radius: 9999px;
+  font-weight: 600;
+  &:hover {
+   --tw-bg-opacity: 1;
+   background-color: rgba(147, 197, 253, var(--tw-bg-opacity));
+  }
 }
 

--- a/app/controllers/api/translations_controller.rb
+++ b/app/controllers/api/translations_controller.rb
@@ -2,22 +2,19 @@ class Api::TranslationsController < ApplicationController
   require 'httpclient'
 
   def translate
-    # @answer = current_user.answers.find(params[:id])
+    @question = Question.find(params[:id])
     api_key = Rails.application.credentials.deepl[:api_key]
     uri = "https://api-free.deepl.com/v2/translate"
     client = HTTPClient.new
     query = {
       auth_key: api_key,
-      text: "this is an answer",
-      target_lang: "JA"
+      text: @question.content,
+      target_lang: "EN"
     }
     headers = {
       Authorization: api_key
     }
     @response = client.get(uri, body: query, header: headers)
-
     render json: @response.body
-
-
   end
 end

--- a/app/javascript/src/answers/Courses.vue
+++ b/app/javascript/src/answers/Courses.vue
@@ -20,6 +20,14 @@
      <router-link to="/" class="finish-btn">
       終了する
      </router-link>
+
+    <!-- translation courseの時だけ表示する -->
+     <div v-if="mode_num == 3">
+        <button @click="translateWithDeepL" class="access-deepl-btn">
+          AI翻訳の結果を確認する
+        </button>
+        <h1 class="result">翻訳結果: {{result}}</h1>
+     </div>
   </div>
 
 
@@ -31,13 +39,10 @@
 
 
   export default {
-     beforeRouteLeave (to, from, next) {
-       next(this.$clearInterval(this.$intervals))
-     },
-
-
+   beforeRouteLeave (to, from, next) {
+      next(this.$clearInterval(this.$intervals))
+    },
     name: 'Courses',
-
     data() {
       return {
         question: {
@@ -47,7 +52,8 @@
           content: ""
         },
         mode_num: this.$route.query.mode_num,
-        answersCreatedToday: ""
+        answersCreatedToday: "",
+        result: ""
       }
     },
     mounted() {
@@ -103,7 +109,15 @@
        .then(response => {
          this.answersCreatedToday = response.data
        })
-     }
+     },
+     //DeepL apiを叩くためのmethod
+     translateWithDeepL: function() {
+       const question_id = this.question.id
+        axios.get('/api/translate/'+ question_id)
+        .then(response => {
+          this.result = response.data.translations[0].text
+        })
+      }
     }
   }
 </script>

--- a/app/javascript/src/answers/Edit.vue
+++ b/app/javascript/src/answers/Edit.vue
@@ -21,9 +21,6 @@
     query: {created_at: date}}" class="to-answer-index-btn">
     　回答一覧に戻る
   　</router-link>
-<!-- 
-   <button @click="translateWithDeepL" class="edit-save-btn">翻訳する</button>
-   <h3 class="result">結果を表示：{{result}}</h3> -->
   </div>
 </template>
 
@@ -47,8 +44,6 @@
         },
         course: "",
         date: "",
-        result: "",
-
       }
     },
     mounted() {
@@ -71,7 +66,6 @@
           }
           this.answer= response.data
           this.date = response.data.date
-          this.deeplApiKey = response.data.deeplKey
         })
       },
       saveEditedAnswer: function() {
@@ -89,13 +83,6 @@
           })
         }
       },
-      translateWithDeepL: function() {
-        axios.get('/api/translate')
-        .then(response => {
-          this.result = response.data.translations[0].text
-          console.log(response.data.translations[0].text)
-        })
-      }
     }
   }
 </script>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -68,7 +68,7 @@ Rails.application.routes.draw do
   end
 
   namespace :api, format: 'json' do
-    get '/translate', to: 'translations#translate'
+    get '/translate/:id', to: 'translations#translate'
   end
 
   match '*path', :to => 'application#error404', :via => :all


### PR DESCRIPTION
## 変更の概要

* Translation courseに翻訳結果表示機能追加(DeepL api)

## なぜこの変更をするのか

* 瞬間英作文コースで模範回答を表示するため

## やったこと

* [x] api/translations_controllerにquestion_idのparamsを受け取ってquestionのcontentをtext項目に代入するよう追記
* [x] routes.rbにtranslate/:idとし、questionのidをparamsとしてcontrollerに渡せるよう追記
* [x] answers/Courses.vueのtemplateにmode_numが３の時だけ翻訳機能を表示するよう実装
* [x] answers/Courses.vueのmethodsにdeepl apiを叩くようコントローラーにアクセスするメソッドを追記
* [x] 上記機能のcssをanswers.scssに追加