### PR TITLE
style: fix dictionaries css

### DIFF
--- a/app/assets/stylesheets/items.scss
+++ b/app/assets/stylesheets/items.scss
@@ -66,7 +66,8 @@
     font-size: 0.75rem;
   }
  padding: 8px;
- height: 96px;
+ width: 150px;
+ height: 64px;
  background-color: #ffffff;
  border-style: solid;
  border-width: 1px;
@@ -79,8 +80,8 @@
     height: 72px;
     font-size: 0.75rem;
   }
- padding: 8px;
- height: 96px;
+ padding: 4px;
+ height: 64px;
  background-color: #ffffff;
  border-style: solid;
  border-width: 1px;

--- a/app/controllers/api/translations_controller.rb
+++ b/app/controllers/api/translations_controller.rb
@@ -11,10 +11,7 @@ class Api::TranslationsController < ApplicationController
       text: @question.content,
       target_lang: "EN"
     }
-    headers = {
-      Authorization: api_key
-    }
-    @response = client.get(uri, body: query, header: headers)
+    @response = client.get(uri, query: query)
     render json: @response.body
   end
 end


### PR DESCRIPTION
## 変更の概要

* dictionaries/Dictionary.vueのcss修正

## なぜこの変更をするのか

* 単語帳のレイアウトの違和感削減

## やったこと

* [x] itemsのcontentとmeaningの枠のwidth を固定
* [x] translations controllerの不要記述を削除