### PR TITLE
style: if used with smartphone, active is applied instead of hover

### DIFF
--- a/app/assets/stylesheets/answers.scss
+++ b/app/assets/stylesheets/answers.scss
@@ -54,6 +54,12 @@
 }
 
 .next-question-btn {
+  @media screen and (min-width: 480px) {
+    &:hover {
+      --tw-bg-opacity: 1;
+      background-color: rgba(147, 197, 253, var(--tw-bg-opacity));
+    }
+  }
   padding-top: 8px;
   padding-bottom: 8px;
   padding-right: 16px;
@@ -68,7 +74,7 @@
   border-color: rgba(59, 130, 246, var(--tw-border-opacity));
   border-radius: 9999px;
   font-weight: 600;
-  &:hover {
+  &:active {
     --tw-bg-opacity: 1;
     background-color: rgba(147, 197, 253, var(--tw-bg-opacity));
   }

--- a/app/assets/stylesheets/custom.scss
+++ b/app/assets/stylesheets/custom.scss
@@ -42,6 +42,10 @@
 .user-page {
   @media screen and (max-width: 480px) {
     margin-right: 65px;
+    &:active {
+      --tw-bg-opacity: 1;
+      background-color: rgba(252, 211, 77, var(--tw-bg-opacity));
+    }
   }
   padding: 4px;
   margin-right: 80px;
@@ -318,12 +322,17 @@
 }
 
 .mypage-link {
+  @media screen and (min-width: 480px) {
+    &:hover {
+      background-color: rgba(252, 211, 77, var(--tw-bg-opacity));
+    }
+  }
   background-color: rgba(245, 158, 11, var(--tw-bg-opacity));
   border-style: solid;
   border-width: 1px;
   border-color: #ffffff;
   display: block;
-  &:hover {
+  &:active {
     background-color: rgba(252, 211, 77, var(--tw-bg-opacity));
   }
 }
@@ -340,12 +349,17 @@
 }
 
 .dictionary-link{
+  @media screen and (min-width: 480px) {
+    &:hover {
+      background-color: rgba(110, 231, 183, var(--tw-bg-opacity));
+    }
+  }
   background-color: rgba(16, 185, 129, var(--tw-bg-opacity));
   border-style: solid;
   border-width: 1px;
   border-color: #ffffff;
   display: block;
-  &:hover {
+  &:active {
     background-color: rgba(110, 231, 183, var(--tw-bg-opacity));
   }
 }

--- a/app/assets/stylesheets/static_pages.scss
+++ b/app/assets/stylesheets/static_pages.scss
@@ -127,6 +127,13 @@
 }
 
 .start-btn {
+  @media screen and (min-width: 480px) {
+    &:hover {
+      color: #000000;
+      background-color: white;
+      border-color: rgba(252, 211, 77, var(--tw-border-opacity));
+    }
+  }
   padding-top: 4px;
   padding-bottom: 4px;
   padding-right: 16px;
@@ -138,8 +145,8 @@
   border-color: white;
   border-radius: 9999px;
   font-weight: 600;
-  &:hover {
-    color: black;
+  &:active {
+    color: #000000;
     background-color: white;
     border-color: rgba(252, 211, 77, var(--tw-border-opacity));
   }


### PR DESCRIPTION
## 変更の概要

* スマホからの使用においてはhoverの代わりにactiveを適用

## なぜこの変更をするのか

* レスポンシブデザインのため

## やったこと

* [x] headerのマイメニューボタン、homeのstartボタン、MyMenu.vueのMymenuおよびdictionaryボタンのhoverをスマホ使用時はactiveが適用されるようcss修正