### PR TITLE
ゲストログイン機能のエラー修正

### DIFF
--- a/app/controllers/api/answers_controller.rb
+++ b/app/controllers/api/answers_controller.rb
@@ -1,5 +1,5 @@
 class Api::AnswersController < ApplicationController
-  before_action :logged_in_user, only: [:index, :new, :create, :edit, :update]
+  before_action :logged_in_user, only: [:index, :create, :edit, :update]
   before_action :not_guest_user, only: [:index, :edit, :update]
 
   def index

--- a/app/javascript/src/answers/Courses.vue
+++ b/app/javascript/src/answers/Courses.vue
@@ -70,27 +70,34 @@
         })
       },
       saveAnswer: function() {
-        axios.post('/api/answers', {
-          answer: this.answer,
-          id: this.id,
-          mode_num: this.mode_num
-        })
-        .then(response => {
-          this.answer.content = ""
-          this.getRandomQuestion();
-          this.$clearInterval(this.$intervals);
-          this.startTimer();
-          //作成されたanswerが本日一個めなら連続学習日数記録を更新する
-          if(this.answersCreatedToday === 0){
-            this.$store.commit('countSequentialDays')
-          }
-        })
-         .catch(err => {
+        if(this.$store.notGuest) {
+          axios.post('/api/answers', {
+            answer: this.answer,
+            id: this.id,
+            mode_num: this.mode_num
+          })
+          .then(response => {
             this.answer.content = ""
             this.getRandomQuestion();
             this.$clearInterval(this.$intervals);
             this.startTimer();
-         })
+            //作成されたanswerが本日一個めなら連続学習日数記録を更新する
+            if(this.answersCreatedToday === 0){
+              this.$store.commit('countSequentialDays')
+            }
+          })
+           .catch(err => {
+              this.answer.content = ""
+              this.getRandomQuestion();
+              this.$clearInterval(this.$intervals);
+              this.startTimer();
+           })
+        } else {
+            this.answer.content = ""
+            this.getRandomQuestion();
+            this.$clearInterval(this.$intervals);
+            this.startTimer();
+        }
       },
       startTimer: function() {
         let i = 60;
@@ -105,10 +112,12 @@
       }, 1000)
      },
      getAnswersCreatedToday: function () {
-       axios.get('/api/questions/new')
-       .then(response => {
-         this.answersCreatedToday = response.data
-       })
+       if(this.$store.notGuest) {
+         axios.get('/api/questions/new')
+         .then(response => {
+           this.answersCreatedToday = response.data
+         })
+       }
      },
      //DeepL apiを叩くためのmethod
      translateWithDeepL: function() {

--- a/app/javascript/src/components/Header.vue
+++ b/app/javascript/src/components/Header.vue
@@ -51,7 +51,7 @@
 
       <!-- ゲストユーザーに表示されるメニュー -->
       <div v-else-if="$store.state.guest">
-        <button @click="destroySession" class="guest-menu">
+        <button @click="logoutAsGuest" class="guest-menu">
           ログアウト
         </button>
       </div>
@@ -104,6 +104,16 @@
             time: 3000
           });
         })
+      },
+      logoutAsGuest: function() {
+        this.$store.commit('logout')
+        this.$flashMessage.show({
+            type: 'success',
+            title: 'Logout',
+            text:'ログアウトしました',
+            time: 3000
+          });
+        this.$router.push({ path: '/'})
       },
       //退会メソッド
       deleteUser: function(id) {

--- a/app/javascript/src/pages/Home.vue
+++ b/app/javascript/src/pages/Home.vue
@@ -92,8 +92,6 @@
     methods: {
       // ゲストログインメソッド
       loginAsGuest: function () {
-        axios.post('/api/guest_sign_in')
-        .then(response => {
            this.$store.commit('login')
            this.$store.commit('notGuest') //notGuestをfalseにする
            this.$store.commit('inGuest')　//inGuestをtrueにする
@@ -103,14 +101,6 @@
             text:'ゲストユーザーとしてログインに成功しました',
             time: 3000
           });
-        })
-        .catch(error => {
-          this.$flashMessage.show({
-            type: 'Error',
-            text: 'エラーが発生しました',
-            time: 3000
-          })
-        });
       }
     }
   }

--- a/spec/requests/api/answers_request_spec.rb
+++ b/spec/requests/api/answers_request_spec.rb
@@ -77,13 +77,6 @@ RSpec.describe "Answers", type: :request do
       end
     end
 
-    describe "GET/ new" do
-      it "login_pathにリダイレクトする" do
-        get new_api_answer_path(mode_num: 1)
-        expect(response).to redirect_to login_path
-      end
-    end
-
     describe "POST/ create" do
       it "answerが作成されず、login_pathにリダイレクトする" do
         expect{

--- a/spec/requests/api/password_resets_request_spec.rb
+++ b/spec/requests/api/password_resets_request_spec.rb
@@ -21,15 +21,6 @@ RSpec.describe "Api::PasswordResets", type: :request do
     end
   end
 
-  # describe "GET /edit" do
-  #   context "メールアドレス・トークンが有効な場合" do
-  #     it "成功レスポンス200を返す" do
-  #       get edit_password_reset_path(user.reset_token, email: user.email)
-  #       expect(response).to have_http_status "200"
-  #     end
-  #   end
-  # end
-
   describe "patch /update" do
    context "無効なパスワードとパスワード確認" do
      it "エラー400を返す" do


### PR DESCRIPTION
## 変更の概要

*ゲストログインをhttpリクエストを介さず機能するよう修正

## なぜこの変更をするのか

* 複数ユーザーが同時にゲストログイン機能を利用するとエラーが起きるため
## やったこと

* [x] Home.vueのguest loginボタンを押した際はvuexでゲストログイン中状態に変更するだけの動作に修正
* [x] Header.vueのゲストログイン中のログアウトボタンについてcontrollerのlogoutメソッドは介さず単にvuexの状態を変更するだけの動作に変更
* [x] api/answers_controllerのbefore_actionからログイン中でなくともnewアクションを実行できるよう修正（vue-router側で未ログインユーザーのアクセスは遮断できている）
* [x] answers/Courses.vueのanswer保存ボタンを押した際、ユーザーがゲストならば保存動作を行わず次の問題を表示するよう設定
* [x] Courses.vueにアクセス時にマウントされるgetAnswersCreatedToday()はゲストログイン時エラーを発するためif文でそれを隠した
