### PR TITLE
style: fix deepl result text's font on Courses.vue

### DIFF
--- a/app/assets/stylesheets/answers.scss
+++ b/app/assets/stylesheets/answers.scss
@@ -250,6 +250,7 @@
   border-width: 1px;
   border-radius: 0.25rem;
   text-align: left;
+  font-weight: bold;
 }
 
 .access-deepl-btn {


### PR DESCRIPTION
## 変更の概要

* deepl の結果テキストのcss変更

## なぜこの変更をするのか

* UI向上

## やったこと

* [x] Courses.vueのdeepl textのfontをboldに設定