### PR TITLE
refactor: remove unnecessary code from api/answers_controller

### DIFF
--- a/app/controllers/api/answers_controller.rb
+++ b/app/controllers/api/answers_controller.rb
@@ -24,7 +24,6 @@ class Api::AnswersController < ApplicationController
     @answer = current_user.answers.find(params[:id])
     @date = @answer.created_at.to_date
     @question = Question.find_by(id: @answer.question_id)
-    @deepl_api_key = Rails.application.credentials.deepl[:api_key]
   end
 
   def update


### PR DESCRIPTION
## 変更の概要

*api/answers_controllerから不要なコードを削除
## なぜこの変更をするのか

* リファクタリング

## やったこと

* [x] api/answers_controllerのeditアクションにdeepl api 導入時の名残りのコードが残っていたため削除